### PR TITLE
Data deploy versioning increment

### DIFF
--- a/inner-loop/src/aip/inner/deploy.py
+++ b/inner-loop/src/aip/inner/deploy.py
@@ -88,8 +88,9 @@ def data(
         else:
             data_asset.tags = tags
 
-    # Due to data assets occasionally using non-integer versions, derive the next
-    # integer version from existing workspace entries to keep updates deterministic.
+    # Due to data assets occasionally using non-integer versions,
+    # derive the next integer version from existing workspace entries 
+    # to keep updates deterministic.
     list_data_ws = getdata(
         client=client,
         name=data_asset.name,

--- a/inner-loop/test_deploy_versioning.py
+++ b/inner-loop/test_deploy_versioning.py
@@ -89,7 +89,7 @@ def test_deploy_data_ignores_non_integer_versions_when_bumping():
 
 def test_deploy_data_starts_at_one_when_no_prior_assets_exist():
     data_asset = MagicMock(name="data_asset")
-    data_asset.name = "training-data"
+    data_asset.name = "training-data" 
     data_asset.tags = None
 
     client = MagicMock(name="client")


### PR DESCRIPTION
## What
When deploying a data asset, version is now bumped incrementally.

## Why
If version is specified in the data assets yaml file, and the data isn't exactly equal to a data assets with the same version, the deployment would fail. Now it will be deployed, if necessary with an incrementally bumped version. The new version is available in the step output.

## Changes
This affects the "Deploy data" action.

## Validation
- tests passed
- docker build passed
