### PR TITLE
Data version set on asset, instead of argument in method

### DIFF
--- a/inner-loop/src/aip/inner/deploy.py
+++ b/inner-loop/src/aip/inner/deploy.py
@@ -112,7 +112,6 @@ def data(
     print("[deploy data] Creating or updating data asset")
     data_result = client.data.create_or_update(
         data=data_asset,
-        version=latest_ws_version,
     )
 
     print(f"[deploy data] ✅ Data asset deployed successfully")

--- a/inner-loop/src/aip/inner/util.py
+++ b/inner-loop/src/aip/inner/util.py
@@ -101,7 +101,7 @@ def load_safe_tags(tags: None|str) -> dict[str, str]:
         res :dict[str,str] = dict()
         tl = re.split(r",\s*",tags)
         for t in tl:
-            kv = re.split(r"\s*=\s*",t,1)
+            kv = re.split(r"\s*=\s*",t,maxsplit=1)
             if type(kv)==str:
                 key=kv
                 val=None

--- a/inner-loop/test_deploy_versioning.py
+++ b/inner-loop/test_deploy_versioning.py
@@ -46,8 +46,8 @@ def test_deploy_data_uses_next_integer_version_from_workspace_assets():
     assert data_asset.version == "8"
     client.data.create_or_update.assert_called_once_with(
         data=data_asset,
-        version="8",
     )
+    assert "version" not in client.data.create_or_update.call_args.kwargs
 
 
 def test_deploy_data_ignores_non_integer_versions_when_bumping():
@@ -83,8 +83,8 @@ def test_deploy_data_ignores_non_integer_versions_when_bumping():
     assert data_asset.version == "3"
     client.data.create_or_update.assert_called_once_with(
         data=data_asset,
-        version="3",
     )
+    assert "version" not in client.data.create_or_update.call_args.kwargs
 
 
 def test_deploy_data_starts_at_one_when_no_prior_assets_exist():
@@ -115,5 +115,5 @@ def test_deploy_data_starts_at_one_when_no_prior_assets_exist():
     assert data_asset.version == "1"
     client.data.create_or_update.assert_called_once_with(
         data=data_asset,
-        version="1",
     )
+    assert "version" not in client.data.create_or_update.call_args.kwargs


### PR DESCRIPTION
On inner-loop deploy data, data version set on asset, instead of argument in method