### PR TITLE
Waitfor job : aml-token required

### DIFF
--- a/inner-loop/README.md
+++ b/inner-loop/README.md
@@ -185,7 +185,7 @@ The action supports two authentication methods:
     filepath: ./jobs/my-job.yaml
 ```
 
-**Note:** The `aml-token` input is required for job operations. This token has the Azure ML scope (`https://ml.azure.com/.default`) and is provided by the Azure login action.
+**Note:** When token-based authentication is used, `deploy job`, `deploy sweep-job`, and `waitfor job` accept an `aml-token` with the `https://ml.azure.com/.default` scope. It is optional when `DefaultAzureCredential` is available locally.
 
 ### Deploy Online Endpoint
 
@@ -285,6 +285,22 @@ instance_count: 1
     tags: "stage=build"
 ```
 
+### Wait for Job Completion
+
+```yaml
+- uses: ./inner-loop
+  with:
+    verb: waitfor
+    subject: job
+    token: ${{ steps.azure-login.outputs.access-token }}
+    expires-on: ${{ steps.azure-login.outputs.expires-on }}
+    aml-token: ${{ steps.azure-login.outputs.aml-token }}
+    subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+    resource-group: my-resource-group
+    workspace-name: my-workspace
+    job-name: my-training-job
+```
+
 The waitfor verb polls Azure ML every 10 seconds (up to 30 minutes) until the specified asset exists and reports a success status. If the asset reports a failure state or the timeout expires, the action stops with a failure, allowing pipelines to halt early when provisioned artifacts break.
 
 ### Share to Registry with Stage Promotion
@@ -333,7 +349,7 @@ The waitfor verb polls Azure ML every 10 seconds (up to 30 minutes) until the sp
 | `subject` | Yes | Target subject: `data`, `environment`, `component`, `model`, `job`, `online-endpoint`, or `online-deployment` |
 | `token` | No* | Access token from Azure login action (*required for GitHub Actions) |
 | `expires-on` | No* | Token expiration timestamp from Azure login action (*required for GitHub Actions) |
-| `aml-token` | No* | Access token with Azure ML scope (*required for job operations) |
+| `aml-token` | No | Access token with Azure ML scope for `deploy job`, `deploy sweep-job`, and `waitfor job`; optional when `DefaultAzureCredential` is available locally |
 | `tenant-id` | No | Azure tenant ID (required for token-based auth) |
 | `subscription-id` | Yes | Azure subscription ID |
 | `resource-group` | Yes | Azure resource group name |

--- a/inner-loop/action.yaml
+++ b/inner-loop/action.yaml
@@ -15,7 +15,7 @@ inputs:
     description: "From azLogin action. Required unless running locally."
     required: false
   aml-token:
-    description: "Access token with Azure ML scope (https://ml.azure.com/.default). Required for job operations."
+    description: "Access token with Azure ML scope (https://ml.azure.com/.default) for deploy job, deploy sweep-job, and waitfor job. Optional when DefaultAzureCredential is available locally."
     required: false
   tenant-id:
     description: "Azure tenant ID"

--- a/inner-loop/src/aip/inner/action_entrypoint.py
+++ b/inner-loop/src/aip/inner/action_entrypoint.py
@@ -227,7 +227,7 @@ COMMAND_SPECS = {
     ("waitfor", "job"): _spec(
         "job-name",
         positional_aliases=("job-ref",),
-        option_inputs=_WAIT_OPTIONS,
+        option_inputs=_WAIT_OPTIONS + ("aml-token",),
         environment_inputs=_WAIT_ENV,
     ),
     ("waitfor", "online-endpoint"): _spec(

--- a/inner-loop/src/aip/inner/waitfor.py
+++ b/inner-loop/src/aip/inner/waitfor.py
@@ -12,6 +12,7 @@ from azure.core.exceptions import HttpResponseError, ResourceNotFoundError
 from azure.identity import DefaultAzureCredential
 
 from .util import (
+    empty_string_to_none,
     get_workspace_client,
     load_safe_tags,
     get_ref_properties,
@@ -689,6 +690,7 @@ def job(
     job_name: str,
     token: Optional[str] = None,
     expires_on: Optional[int] = None,
+    aml_token: Annotated[Optional[str], typer.Option("--aml-token", callback=empty_string_to_none)] = None,
     tags: Annotated[
         Optional[str],
         typer.Option(help="Tags in the config file to use", callback=load_safe_tags),
@@ -702,6 +704,7 @@ def job(
         workspace_name=workspace_name,
         token=token,
         expires_on=expires_on,
+        aml_token=aml_token,
     )
 
     # Create token manager for automatic token refresh during long waits

--- a/inner-loop/test_action_contract.py
+++ b/inner-loop/test_action_contract.py
@@ -174,6 +174,16 @@ def test_new_action_mode_dispatches_every_command(command: tuple[str, str]):
     assert invocation.argv[:2] == command
 
 
+def test_waitfor_job_forwards_aml_token():
+    values = _valid_inputs(("waitfor", "job"))
+    values["aml-token"] = "aml-token-value"
+
+    invocation = adapt_action_environment(_action_environment(values))
+
+    option_index = invocation.argv.index("--aml-token")
+    assert invocation.argv[option_index + 1] == "aml-token-value"
+
+
 @pytest.mark.parametrize(
     ("command", "input_name"),
     APPLICABLE_CASES,

--- a/inner-loop/test_util.py
+++ b/inner-loop/test_util.py
@@ -21,22 +21,27 @@ Total: 31 tests, all passing and documenting current behavior including bugs.
 """
 
 import os
-import sys
 import pytest
 import tempfile
 from pathlib import Path
 from unittest.mock import patch, mock_open, MagicMock
 from collections import namedtuple
 
-# Mock Azure modules to avoid import errors
-sys.modules['azure'] = MagicMock()
-sys.modules['azure.core'] = MagicMock()
-sys.modules['azure.core.credentials'] = MagicMock()
-sys.modules['azure.identity'] = MagicMock()
-sys.modules['azure.ai'] = MagicMock()
-sys.modules['azure.ai.ml'] = MagicMock()
+from aip.inner.util import AML_SCOPE, Credential, github_output, load_safe_tags, get_ref_properties
 
-from aip.inner.util import github_output, load_safe_tags, get_ref_properties
+
+class TestCredential:
+    """Test suite for Azure SDK credential scope routing"""
+
+    def test_get_token_selects_aml_token_only_for_aml_scope(self):
+        with patch(
+            "aip.inner.util.AccessToken",
+            side_effect=lambda token, expires_on: MagicMock(token=token, expires_on=expires_on),
+        ):
+            credential = Credential("arm-token", 1234567890, "aml-token")
+
+        assert credential.get_token(AML_SCOPE).token == "aml-token"
+        assert credential.get_token("https://management.azure.com/.default").token == "arm-token"
 
 
 class TestGithubOutput:

--- a/inner-loop/test_waitfor_job.py
+++ b/inner-loop/test_waitfor_job.py
@@ -1,0 +1,42 @@
+"""Focused tests for waitfor job authentication routing."""
+
+from unittest.mock import MagicMock, patch
+
+from aip.inner import waitfor
+
+
+def test_waitfor_job_routes_aml_and_arm_tokens_separately():
+    entity = MagicMock()
+    entity.name = "training-job"
+    client = MagicMock()
+    client.jobs.get.return_value = entity
+
+    def complete_wait(**kwargs):
+        return kwargs["fetch_entity"](), "completed"
+
+    with (
+        patch("aip.inner.waitfor.get_workspace_client", return_value=client) as workspace_client,
+        patch("aip.inner.waitfor.TokenManager") as token_manager,
+        patch("aip.inner.waitfor._wait_for_asset", side_effect=complete_wait),
+        patch("aip.inner.waitfor.github_output"),
+    ):
+        waitfor.job(
+            "subscription",
+            "resource-group",
+            "workspace",
+            "training-job",
+            token="arm-token",
+            expires_on=1234567890,
+            aml_token="aml-token",
+        )
+
+    workspace_client.assert_called_once_with(
+        subscription_id="subscription",
+        resource_group="resource-group",
+        workspace_name="workspace",
+        token="arm-token",
+        expires_on=1234567890,
+        aml_token="aml-token",
+    )
+    token_manager.assert_called_once_with(token="arm-token", expires_on=1234567890)
+    client.jobs.get.assert_called_once_with(name="training-job")


### PR DESCRIPTION
## What
inner-loop waitfor job now requires aml-token

## Why
Job operations in AML require specifically scoped token.

## Changes
aml-token is a necessary input for waitfor job action.

## Validation
- tests passed
- docker build passed
