### PR TITLE
read mlflow metrics without .value

### DIFF
--- a/outer-loop/src/aip/outer/util.py
+++ b/outer-loop/src/aip/outer/util.py
@@ -298,7 +298,8 @@ class AzureMLBackend:
         """
         info = run.get("info", {})
         data = run.get("data", {})
-        metrics = {m["key"]: m["value"] for m in data.get("metrics", [])}
+        # AzureML's MLflow proxy omits "value" for NaN metrics, since JSON has no NaN.
+        metrics = {m["key"]: m["value"] for m in data.get("metrics", []) if "value" in m}
         tags = {t["key"]: t["value"] for t in data.get("tags", [])}
         return {
             "run_id": info.get("run_id", ""),
@@ -339,7 +340,8 @@ class AzureMLBackend:
         """Return the final metric values for a single run."""
         data = self._get("/api/2.0/mlflow/runs/get", params={"run_id": run_id})
         run_data = data.get("run", {}).get("data", {})
-        return {m["key"]: m["value"] for m in run_data.get("metrics", [])}
+        # AzureML's MLflow proxy omits "value" for NaN metrics, since JSON has no NaN.
+        return {m["key"]: m["value"] for m in run_data.get("metrics", []) if "value" in m}
 
     def compare_runs(
         self,

--- a/outer-loop/test_outer.py
+++ b/outer-loop/test_outer.py
@@ -608,6 +608,49 @@ class TestAzureMLBackend:
 
         assert metrics == {"f1": 0.85, "loss": 0.12}
 
+    def test_get_run_metrics_skips_nan_metrics_without_value(self):
+        backend = self._make_backend()
+        backend._session.get.return_value = MagicMock(
+            raise_for_status=lambda: None,
+            json=lambda: {"run": {"info": {}, "data": {
+                "metrics": [
+                    {"key": "cv_accuracy", "value": 1.0},
+                    {"key": "cv_accuracy_std", "timestamp": "1785399783655"},
+                ],
+                "tags": [],
+            }}},
+        )
+
+        metrics = backend.get_run_metrics("r1")
+
+        assert metrics == {"cv_accuracy": 1.0}
+
+    def test_normalize_run_skips_nan_metrics_without_value(self):
+        backend = self._make_backend()
+        backend._session.get.return_value = MagicMock(
+            status_code=200,
+            json=lambda: {"experiment": {"experiment_id": "exp1"}},
+            raise_for_status=lambda: None,
+        )
+        backend._session.post.return_value = MagicMock(
+            status_code=200,
+            raise_for_status=lambda: None,
+            json=lambda: {"runs": [{
+                "info": {"run_id": "r1", "status": "FINISHED"},
+                "data": {
+                    "metrics": [
+                        {"key": "cv_f1_weighted", "value": 1.0},
+                        {"key": "cv_f1_weighted_std", "timestamp": "1785399783655"},
+                    ],
+                    "tags": [],
+                },
+            }]},
+        )
+
+        runs = backend.get_experiment_runs("my-exp")
+
+        assert runs[0]["metrics"] == {"cv_f1_weighted": 1.0}
+
     def test_compare_runs_with_explicit_run_ids(self):
         backend = self._make_backend()
         responses = {


### PR DESCRIPTION
When reading mlflow metrics, don't use .value