### PR TITLE
chore: Paging assets and int version handling

### DIFF
--- a/inner-loop/src/aip/inner/arm.py
+++ b/inner-loop/src/aip/inner/arm.py
@@ -25,7 +25,6 @@ ML_PROVIDER = "Microsoft.MachineLearningServices"
 REST_API_VERSION = "2025-10-01-preview"
 
 REQUEST_TIMEOUT_SECONDS = 30
-VERSION_PAGE_SIZE = 100
 # Buffer time in seconds before token expiry to trigger refresh
 TOKEN_REFRESH_BUFFER_SECONDS = 5 * 60
 
@@ -332,10 +331,12 @@ class AssetClient:
 
         `list_view_type` defaults to All because archived versions still occupy their
         version number and must be counted when deriving the next one.
+
+        No `$top` or `$orderBy`: the component version API rejects both outright.
         """
         url = self._url(
             f"{_collection(kind)}/{urllib.parse.quote(name)}/versions",
-            **{"listViewType": list_view_type, "$top": VERSION_PAGE_SIZE},
+            **{"listViewType": list_view_type},
         )
         versions: list[AssetVersion] = []
         while url:

--- a/inner-loop/src/aip/inner/share.py
+++ b/inner-loop/src/aip/inner/share.py
@@ -108,7 +108,7 @@ def data(
     if list_data_reg:
         for d in list_data_reg:
             lrv = parse_int_version(d.version)
-            if lrv and lrv>latest_reg_version:
+            if lrv is not None and lrv>latest_reg_version:
                 latest_reg_version=lrv
     latest_reg_version=str(latest_reg_version+1)
     
@@ -230,11 +230,13 @@ def environment(
         req_int_version=True
     )
     # find latest registry version to use
-    latest_reg_version = parse_int_version(ws_env.version) or 0
+    latest_reg_version = parse_int_version(ws_env.version)
+    if latest_reg_version is None:
+        latest_reg_version = 0
     if list_env_reg:
         for e in list_env_reg:
             lrv = parse_int_version(e.version)
-            if lrv and lrv>latest_reg_version:
+            if lrv is not None and lrv>latest_reg_version:
                 latest_reg_version=lrv
         latest_reg_version=latest_reg_version+1 # only if name exists
     print("[share environment] Sharing environment to registry")
@@ -357,7 +359,7 @@ def model(
     if list_m_reg:
         for m in list_m_reg:
             lrv = parse_int_version(m.version)
-            if lrv and lrv>latest_reg_version:
+            if lrv is not None and lrv>latest_reg_version:
                 latest_reg_version=lrv
     latest_reg_version=str(latest_reg_version+1)
 
@@ -500,7 +502,7 @@ def component(
         latest_reg_version = 0
         for c in list_comp_reg:
             lrv = parse_int_version(c.version)
-            if lrv and lrv>latest_reg_version:
+            if lrv is not None and lrv>latest_reg_version:
                 latest_reg_version=lrv
         latest_reg_version=str(latest_reg_version+1)
 

--- a/inner-loop/test_arm.py
+++ b/inner-loop/test_arm.py
@@ -157,6 +157,17 @@ class TestAssetClientUrls:
         assert f"listViewType={LIST_VIEW_ALL}" in transport.urls("GET")[0]
         assert transport.urls("GET")[1] == page_two
 
+    def test_version_list_sends_no_top_or_orderby(self):
+        """The component version API rejects both with HTTP 400."""
+        client, transport = _client([(_is_version_list, (200, {"value": []}))])
+
+        client.list_versions("component", "my-asset")
+
+        listed = transport.urls("GET")[0]
+        assert "top" not in listed
+        assert "orderBy" not in listed
+        assert "orderby" not in listed
+
     def test_registry_scope_uses_the_registries_route(self):
         registry_base = (
             f"{ARM_BASE_URL}/subscriptions/sub/resourceGroups/reg-rg"


### PR DESCRIPTION
## What
Paging on GET asset corrected.
Handling of int version now consistent even when version is 0.

## Why
Paging caused a failure for assets with many versions.
Version in registry could have failed under some circumstances.

## Validation
- tests passed
- docker build passed
