### PR TITLE
Filtering jobs by parent and child names

### DIFF
--- a/outer-loop/src/aip/outer/util.py
+++ b/outer-loop/src/aip/outer/util.py
@@ -257,6 +257,14 @@ def _run_name(run: dict) -> str:
     return run.get("run_name") or run.get("tags", {}).get("mlflow.runName", "")
 
 
+def _parent_run_id(run: dict) -> str:
+    """Return the AzureML or MLflow parent run identifier."""
+    return (
+        run.get("parent_run_id")
+        or run.get("tags", {}).get("mlflow.parentRunId", "")
+    )
+
+
 def _select_child_runs(
     runs: list[dict], parent_runs: list[dict], child_run_name: str
 ) -> list[dict]:
@@ -264,7 +272,7 @@ def _select_child_runs(
     parent_ids = {run["run_id"] for run in parent_runs}
     return [
         run for run in runs
-        if run.get("tags", {}).get("mlflow.parentRunId") in parent_ids
+        if _parent_run_id(run) in parent_ids
         and _run_name(run) == child_run_name
     ]
 
@@ -327,6 +335,7 @@ class AzureMLBackend:
             "run_id": info.get("run_id", ""),
             "status": info.get("status", ""),
             "run_name": info.get("run_name", tags.get("mlflow.runName", "")),
+            "parent_run_id": info.get("parent_run_id", info.get("parentRunId", "")),
             "metrics": metrics,
             "tags": tags,
         }

--- a/outer-loop/test_outer.py
+++ b/outer-loop/test_outer.py
@@ -584,6 +584,7 @@ class TestAzureMLBackend:
             "run_id": "r1",
             "status": "FINISHED",
             "run_name": "train",
+            "parent_run_id": "",
             "metrics": {"accuracy": 0.9},
             "tags": {},
         }]
@@ -736,7 +737,8 @@ class TestAzureMLBackend:
             {
                 "run_id": "evaluate-1",
                 "run_name": "evaluate_test",
-                "tags": {"mlflow.parentRunId": "pipeline-1"},
+                "parent_run_id": "pipeline-1",
+                "tags": {},
             },
             {
                 "run_id": "train-1",
@@ -746,7 +748,8 @@ class TestAzureMLBackend:
             {
                 "run_id": "evaluate-other-pipeline",
                 "run_name": "evaluate_test",
-                "tags": {"mlflow.parentRunId": "pipeline-2"},
+                "parent_run_id": "pipeline-2",
+                "tags": {},
             },
         ]
         backend.get_experiment_runs = MagicMock(side_effect=[parent_runs, all_runs])
@@ -762,6 +765,19 @@ class TestAzureMLBackend:
             (('my-exp',), {"max_results": 100, "run_name": "daily-pipeline"}),
             (('my-exp',), {"max_results": 100}),
         ]
+
+    def test_normalize_run_preserves_azureml_parent_run_id(self):
+        normalized = AzureMLBackend._normalize_run({
+            "info": {
+                "run_id": "evaluate-1",
+                "status": "FINISHED",
+                "run_name": "evaluate_test",
+                "parent_run_id": "pipeline-1",
+            },
+            "data": {"metrics": [], "tags": []},
+        })
+
+        assert normalized["parent_run_id"] == "pipeline-1"
 
     def test_get_monitoring_run_returns_none_when_no_runs(self):
         backend = self._make_backend()


### PR DESCRIPTION
## What
Filtering jobs by parent and child names when comparing candidates

## Why
Need to filter on job names that are consistent across runs.

## Validation
- Tests passed
- Docker builds passed
