### PR TITLE
Further work on mlflow pagination of jobs

### DIFF
--- a/docs/tests-overview.md
+++ b/docs/tests-overview.md
@@ -1,0 +1,94 @@
+# Test Overview
+
+This repository has two independently runnable Python test suites, one for each Docker-based GitHub Action. The tests use `pytest`; most are unit or contract tests that replace Azure SDK, Azure Resource Manager, MLflow, and HTTP interactions with mocks or fake transports.
+
+## At a Glance
+
+| Area | Test modules | Collected pytest items | Primary test level |
+| --- | ---: | ---: | --- |
+| Inner loop | 6 | 1,409 | Action-contract matrix and unit tests |
+| Outer loop | 2 | 87 | Action contracts, unit tests, and command-level tests |
+| Total | 8 | 1,496 | Isolated/local tests |
+
+The item count is from `pytest --collect-only` on 2026-08-05. It is higher than the number of test functions because the inner-loop contract tests are heavily parameterized across commands and inputs.
+
+## Test Approach
+
+The suites deliberately avoid live Azure dependencies:
+
+- Azure SDK clients, credentials, ARM responses, MLflow backends, and HTTP sessions are mocked or replaced with in-memory fakes.
+- Command behavior is exercised through Typer's `CliRunner` where command parsing and exit status matter.
+- Files used by commands and GitHub output are created in temporary locations.
+- Action contracts inspect `action.yaml`, the Dockerfile, action environment variables, and the registered Typer/Click command tree.
+
+This makes the tests fast and deterministic, and gives especially strong protection against action/CLI drift. It does not verify an authenticated request against a real Azure ML workspace or MLflow server.
+
+## Inner-Loop Tests
+
+The inner-loop action manages Azure ML asset and endpoint operations. Its test suite is centered on the 30-command action interface and its Azure Resource Manager integration boundary.
+
+| Test module | Items | What it verifies |
+| --- | ---: | --- |
+| [`inner-loop/test_action_contract.py`](../inner-loop/test_action_contract.py) | 1,326 | The complete 30-command action matrix: all applicable action inputs are forwarded, non-applicable and unsupported inputs are rejected without leaking values, required inputs and aliases are validated, blanks are omitted, and legacy invocation remains compatible. It also verifies `action.yaml` exposure, Docker/direct entrypoints, lazy import behavior, and exact agreement between the action contract and the Typer/Click command tree. |
+| [`inner-loop/test_arm.py`](../inner-loop/test_arm.py) | 38 | ARM URL construction, API-version use, pagination, registry resource-group discovery, error redaction, integer-version parsing and selection, archived-version counting, and archived-container recovery behavior. Requests are handled by a recording fake transport. |
+| [`inner-loop/test_batch_lifecycle.py`](../inner-loop/test_batch_lifecycle.py) | 9 | Batch endpoint and deployment creation, tag handling, GitHub outputs, idempotent default-deployment changes, concurrent-change protection, update verification, promotion/rollback, and pinned deployment invocation. |
+| [`inner-loop/test_deploy_versioning.py`](../inner-loop/test_deploy_versioning.py) | 3 | Data-asset version assignment from existing workspace versions, ignoring non-integer versions, and the no-existing-asset case. |
+| [`inner-loop/test_util.py`](../inner-loop/test_util.py) | 32 | Credential scope routing, `GITHUB_OUTPUT` writing, safe tag parsing, and Azure ML asset-reference parsing for simple, workspace, and registry forms. |
+| [`inner-loop/test_waitfor_job.py`](../inner-loop/test_waitfor_job.py) | 1 | Separate routing of ARM and Azure ML tokens for job polling. |
+
+The contract matrix is the dominant source of inner-loop depth. It enumerates command/input combinations rather than sampling a small subset, so a new input, command, or CLI option has a high chance of breaking a focused contract assertion.
+
+## Outer-Loop Tests
+
+The outer-loop action evaluates model evidence, compares runs, and reports decisions. Its tests cover decision logic, CLI boundaries, and normalized access to MLflow-compatible APIs.
+
+| Test module | Items | What it verifies |
+| --- | ---: | --- |
+| [`outer-loop/test_action_contract.py`](../outer-loop/test_action_contract.py) | 13 | The five registered commands, action-mode dispatch, action-input classification and forwarding, required alternatives, rejected unsupported/inapplicable inputs without secret leakage, YAML environment mapping, CLI command-tree consistency, and separation of Docker and direct CLI entrypoints. |
+| [`outer-loop/test_outer.py`](../outer-loop/test_outer.py) | 72 | Weighted candidate scoring and metric directions; policy threshold, priority, and default decisions; fail-closed monitoring-evidence checks; deterministic decision outputs; `evaluate gate` threshold boundaries; backend selection; and Azure ML/MLflow proxy request, pagination, filtering, normalization, parent-child run selection, missing-resource, and missing-metric handling. |
+
+Several outer-loop tests invoke commands through `CliRunner`. These are local integration-style tests of parsing, validation, output, and exit codes, while still mocking backend calls.
+
+## Running the Tests
+
+Run the action suites from their own directories so each uses its own project metadata and source layout.
+
+```powershell
+Push-Location inner-loop
+uv sync --locked
+uv run --with pytest pytest -q
+Pop-Location
+
+Push-Location outer-loop
+uv sync
+uv run --with pytest pytest -q
+Pop-Location
+```
+
+For a fast inventory without executing test bodies:
+
+```powershell
+Push-Location inner-loop
+uv run --with pytest pytest --collect-only -q
+Pop-Location
+
+Push-Location outer-loop
+uv run --with pytest pytest --collect-only -q
+Pop-Location
+```
+
+The inner-loop project requires Python 3.13 or later; outer-loop requires Python 3.12 or later. Both projects configure pytest to treat warnings as errors, with narrowly scoped ignores for current Azure ML and Marshmallow deprecation warnings.
+
+## Automation and Coverage Limits
+
+No checked-in GitHub Actions workflow runs these tests. The repository's only workflow, [`release.yaml`](../.github/workflows/release.yaml), builds and publishes images and pins action image digests. The contributor guidance requires authors to run the relevant suites before requesting review; see [build and release guidance](build-and-releaseguidance.md).
+
+There is no configured coverage-reporting tool or minimum coverage threshold. The current test suite does not include:
+
+- Live Azure ML workspace, registry, endpoint, job, or managed identity tests.
+- Live MLflow service compatibility tests.
+- Docker-container execution tests for the action entrypoints.
+- A pull-request or continuous-integration test workflow.
+- Browser, UI, performance, load, or security scanning tests.
+
+Those boundaries are useful when interpreting a green test run: it validates the repository's action contracts, local control flow, and mocked protocol behavior, but not cloud credentials, Azure service behavior, image runtime behavior, or deployment-time integration.

--- a/outer-loop/src/aip/outer/util.py
+++ b/outer-loop/src/aip/outer/util.py
@@ -341,12 +341,14 @@ class AzureMLBackend:
         }
 
     def get_experiment_runs(
-        self, experiment_name: str, max_results: int = 100, run_name: Optional[str] = None
+        self, experiment_name: str, max_results: Optional[int] = 100, run_name: Optional[str] = None
     ) -> list[dict]:
         """Return a list of runs for an experiment, most recent first.
 
-        If ``run_name`` is supplied, the filter is pushed to the MLflow REST API
-        search query (server-side), which avoids over-fetching runs.
+        If ``run_name`` is supplied, the returned list is filtered client-side.
+        AzureML's MLflow service does not reliably apply a ``mlflow.runName``
+        server-side filter to pipeline runs.
+        Pass ``None`` for ``max_results`` to retrieve every result page.
         """
         try:
             data = self._get(
@@ -358,15 +360,29 @@ class AzureMLBackend:
                 return []
             raise
         experiment_id = data["experiment"]["experiment_id"]
-        body: dict[str, Any] = {
-            "experiment_ids": [experiment_id],
-            "max_results": max_results,
-            "order_by": ["start_time DESC"],
-        }
-        if run_name:
-            body["filter"] = f"tags.`mlflow.runName` = '{run_name}'"
-        runs_data = self._post("/api/2.0/mlflow/runs/search", body)
-        return [self._normalize_run(r) for r in runs_data.get("runs", [])]
+        runs = []
+        page_token = None
+        while True:
+            body: dict[str, Any] = {
+                "experiment_ids": [experiment_id],
+                "max_results": 1000,
+                "order_by": ["start_time DESC"],
+            }
+            if page_token:
+                body["page_token"] = page_token
+            runs_data = self._post("/api/2.0/mlflow/runs/search", body)
+            page_runs = runs_data.get("runs", [])
+            normalized_runs = (self._normalize_run(run) for run in page_runs)
+            if run_name:
+                runs.extend(run for run in normalized_runs if _run_name(run) == run_name)
+            else:
+                runs.extend(normalized_runs)
+            if max_results is not None and len(runs) >= max_results:
+                return runs[:max_results]
+            page_token = runs_data.get("next_page_token")
+            if not page_runs or not page_token:
+                break
+        return runs[:max_results] if max_results is not None else runs
 
     def get_run_metrics(self, run_id: str) -> dict[str, float]:
         """Return the final metric values for a single run."""
@@ -393,8 +409,8 @@ class AzureMLBackend:
                 runs.append(self._normalize_run(data.get("run", {})))
             return runs
         if child_run_name:
-            parent_runs = self.get_experiment_runs(experiment_name, max_results=100, run_name=run_name)
-            all_runs = self.get_experiment_runs(experiment_name, max_results=100)
+            parent_runs = self.get_experiment_runs(experiment_name, max_results=None, run_name=run_name)
+            all_runs = self.get_experiment_runs(experiment_name, max_results=None)
             return _select_child_runs(all_runs, parent_runs, child_run_name)
         return self.get_experiment_runs(experiment_name, max_results=100, run_name=run_name)
 

--- a/outer-loop/test_outer.py
+++ b/outer-loop/test_outer.py
@@ -680,7 +680,7 @@ class TestAzureMLBackend:
         assert result[0]["run_id"] == "r1"
         assert result[1]["run_id"] == "r2"
 
-    def test_get_experiment_runs_with_run_name_sends_filter_in_post_body(self):
+    def test_get_experiment_runs_with_run_name_filters_client_side(self):
         backend = self._make_backend()
         backend._session.get.return_value = MagicMock(
             status_code=200,
@@ -703,9 +703,70 @@ class TestAzureMLBackend:
 
         post_call_kwargs = backend._session.post.call_args
         body = post_call_kwargs[1]["json"]
-        assert body.get("filter") == "tags.`mlflow.runName` = 'baseline-v2'"
+        assert "filter" not in body
         assert len(runs) == 1
         assert runs[0]["tags"]["mlflow.runName"] == "baseline-v2"
+
+    def test_get_experiment_runs_follows_all_pages_when_max_results_is_none(self):
+        backend = self._make_backend()
+        backend._session.get.return_value = MagicMock(
+            status_code=200,
+            json=lambda: {"experiment": {"experiment_id": "exp1"}},
+            raise_for_status=lambda: None,
+        )
+        backend._session.post.side_effect = [
+            MagicMock(
+                raise_for_status=lambda: None,
+                json=lambda: {
+                    "runs": [{"info": {"run_id": "r1"}, "data": {}}],
+                    "next_page_token": "page-2",
+                },
+            ),
+            MagicMock(
+                raise_for_status=lambda: None,
+                json=lambda: {"runs": [{"info": {"run_id": "r2"}, "data": {}}]},
+            ),
+        ]
+
+        runs = backend.get_experiment_runs("my-exp", max_results=None)
+
+        assert [run["run_id"] for run in runs] == ["r1", "r2"]
+        first_body = backend._session.post.call_args_list[0].kwargs["json"]
+        second_body = backend._session.post.call_args_list[1].kwargs["json"]
+        assert first_body["max_results"] == 1000
+        assert second_body["page_token"] == "page-2"
+
+    def test_get_experiment_runs_with_run_name_follows_pages_until_it_finds_matches(self):
+        backend = self._make_backend()
+        backend._session.get.return_value = MagicMock(
+            status_code=200,
+            json=lambda: {"experiment": {"experiment_id": "exp1"}},
+            raise_for_status=lambda: None,
+        )
+        backend._session.post.side_effect = [
+            MagicMock(
+                raise_for_status=lambda: None,
+                json=lambda: {
+                    "runs": [{
+                        "info": {"run_id": "r1", "run_name": "other"},
+                        "data": {"tags": []},
+                    }],
+                    "next_page_token": "page-2",
+                },
+            ),
+            MagicMock(
+                raise_for_status=lambda: None,
+                json=lambda: {"runs": [{
+                    "info": {"run_id": "r2", "run_name": "target"},
+                    "data": {"tags": []},
+                }]},
+            ),
+        ]
+
+        runs = backend.get_experiment_runs("my-exp", max_results=1, run_name="target")
+
+        assert [run["run_id"] for run in runs] == ["r2"]
+        assert backend._session.post.call_count == 2
 
     def test_compare_runs_with_run_name_delegates_to_get_experiment_runs(self):
         backend = self._make_backend()
@@ -726,7 +787,7 @@ class TestAzureMLBackend:
         result = backend.compare_runs("my-exp", run_name="my-run")
 
         post_body = backend._session.post.call_args[1]["json"]
-        assert post_body.get("filter") == "tags.`mlflow.runName` = 'my-run'"
+        assert "filter" not in post_body
         assert result[0]["run_id"] == "r2"
 
     def test_compare_runs_with_parent_and_child_names_selects_only_named_children(self):
@@ -762,8 +823,8 @@ class TestAzureMLBackend:
 
         assert [run["run_id"] for run in result] == ["evaluate-1"]
         assert backend.get_experiment_runs.call_args_list == [
-            (('my-exp',), {"max_results": 100, "run_name": "daily-pipeline"}),
-            (('my-exp',), {"max_results": 100}),
+            (('my-exp',), {"max_results": None, "run_name": "daily-pipeline"}),
+            (('my-exp',), {"max_results": None}),
         ]
 
     def test_normalize_run_preserves_azureml_parent_run_id(self):


### PR DESCRIPTION
## What
Further work on mlflow pagination of jobs
Also added overview of tests to documentation folder.

## Why
When there are many jobs (more than page limit), additional logic is need to retrieve results correctly.

## Changes
outer-loop util.py
docs/tests-overview.md

## Validation
- tests passed
- docker builds passed
