### PR TITLE
Evaluate Gate accepts child-run-name

### DIFF
--- a/outer-loop/README.md
+++ b/outer-loop/README.md
@@ -27,7 +27,17 @@ The Outer Loop action provides a single entry point for all post-training and pr
 Fetches metrics from MLFlow for a specific run (or the latest run in the experiment if `run-id` is omitted), compares each metric against the constraints in `thresholds-file`, and outputs a pass/fail result. If any metric fails or is missing the action exits with code 1, blocking downstream steps.
 
 **Required inputs:** `mlflow-url`, `experiment-name`, `thresholds-file`  
-**Optional inputs:** `run-id`, `token`, `expires-on`
+**Optional inputs:** `run-id`, `child-run-name`, `token`, `expires-on`
+
+Run selection:
+
+| Inputs | Run evaluated |
+|--------|---------------|
+| `run-id` | That run. |
+| `run-id` + `child-run-name` | The child of `run-id` with that MLflow/Studio display name. |
+| neither | The latest run in the experiment. |
+
+Use `run-id` + `child-run-name` for pipeline runs: the inner-loop `waitfor job` command returns the **parent** run ID, while the metrics you want to gate on usually belong to one specific child job. `child-run-name` requires `run-id`, and the command fails if the name matches zero or more than one child — the error lists the parent's available child display names.
 
 **Thresholds file format:**
 
@@ -42,7 +52,7 @@ loss:
 
 See [outer-loop-config.md](outer-loop-config.md#thresholdsyaml----used-by-evaluate-gate) for the full format reference.
 
-**Outputs:** `result` (`pass` | `fail`), `summary` (Markdown table)
+**Outputs:** `result` (`pass` | `fail`), `resolved-run-id` (the run actually evaluated), `summary` (Markdown table)
 
 ---
 
@@ -169,10 +179,10 @@ Autonomous decisions require these MLFlow tags: `aip.monitoring.schema_version=1
 | Input | Description | Required |
 |-------|-------------|----------|
 | `experiment-name` | Azure ML / MLFlow experiment name. | No |
-| `run-id` | Single MLFlow run ID. | No |
+| `run-id` | Single MLFlow run ID. For `evaluate gate`, the run to evaluate, or the parent run when `child-run-name` is also supplied. | No |
 | `run-ids` | Comma-separated list of MLFlow run IDs for multi-run operations. | No |
 | `run-name` | Filter `compare candidates` to runs with this exact display name (`mlflow.runName` tag). Ignored when `run-ids` is also supplied. | No |
-| `child-run-name` | Filter `compare candidates` to child runs with this exact MLflow/Studio display name under parents selected by `run-name`. Ignored when `run-ids` is also supplied. | No |
+| `child-run-name` | Exact MLflow/Studio display name of a child run. For `compare candidates`, filters children under parents selected by `run-name` (ignored when `run-ids` is supplied). For `evaluate gate`, selects which child of `run-id` to evaluate. | No |
 
 ### Config files
 
@@ -204,6 +214,7 @@ Autonomous decisions require these MLFlow tags: `aip.monitoring.schema_version=1
 | Output | Description |
 |--------|-------------|
 | `result` | `pass`/`fail` for `evaluate gate`; recommended action string for `evaluate policy`; JSON signals for `check monitoring`. |
+| `resolved-run-id` | Run ID actually evaluated by `evaluate gate`, after child/latest resolution. |
 | `best-run-id` | Run ID of the best candidate (`compare candidates` only). |
 | `best-run-metrics` | JSON-encoded metrics of the best candidate run (`compare candidates` only). |
 | `summary` | Human-readable Markdown summary, also posted as a GitHub step summary. |
@@ -245,6 +256,29 @@ Autonomous decisions require these MLFlow tags: `aip.monitoring.schema_version=1
     experiment-name: my-training-experiment
     run-id: ${{ steps.train.outputs.run-id }}
     thresholds-file: .azureml/thresholds.yaml
+```
+
+### Evaluate a specific child job of a pipeline run
+
+`waitfor job` returns the parent (pipeline) run ID, so name the child job that holds the metrics.
+
+```yaml
+- name: Evaluate gate on the evaluation step
+  id: gate
+  uses: equinor/ai-platform-actions/outer-loop@main
+  with:
+    verb: evaluate
+    subject: gate
+    token: ${{ steps.azLogin.outputs.token }}
+    expires-on: ${{ steps.azLogin.outputs.expires-on }}
+    mlflow-url: https://mlflow-proxy.cluster.aurora.equinor.com
+    experiment-name: my-training-experiment
+    run-id: ${{ steps.waitfor.outputs.run-id }}
+    child-run-name: evaluate_test
+    thresholds-file: .azureml/thresholds.yaml
+
+- name: Show which run was gated
+  run: echo "Evaluated run: ${{ steps.gate.outputs.resolved-run-id }}"
 ```
 
 ### Compare candidate runs and promote the best

--- a/outer-loop/action.yaml
+++ b/outer-loop/action.yaml
@@ -33,7 +33,9 @@ inputs:
     description: "Azure ML / MLFlow experiment name"
     required: false
   run-id:
-    description: "Single MLFlow run ID"
+    description: |
+      Single MLFlow run ID. For evaluate gate this is the run to evaluate, or the
+      parent (pipeline) run when child-run-name is also supplied.
     required: false
   run-ids:
     description: "Comma-separated list of MLFlow run IDs for multi-run operations"
@@ -45,8 +47,11 @@ inputs:
     required: false
   child-run-name:
     description: |
-      Filter compare candidates to child runs with this exact MLflow/Studio display name
-      under parent runs selected by run-name. Ignored when run-ids is also supplied.
+      Exact MLflow/Studio display name of a child run.
+      For compare candidates it filters child runs under parent runs selected by
+      run-name, and is ignored when run-ids is also supplied.
+      For evaluate gate it selects which child of run-id to evaluate; run-id is
+      then required and must identify the parent run.
     required: false
 
   # --- Config files ---
@@ -113,6 +118,8 @@ inputs:
 outputs:
   result:
     description: "Pass/fail result for gate evaluation, or action recommendation for policy"
+  resolved-run-id:
+    description: "Run ID actually evaluated by evaluate gate, after child/latest resolution"
   best-run-id:
     description: "Run ID of the best candidate (compare candidates)"
   best-run-metrics:

--- a/outer-loop/src/aip/outer/action_entrypoint.py
+++ b/outer-loop/src/aip/outer/action_entrypoint.py
@@ -93,6 +93,7 @@ COMMAND_SPECS = {
     ("evaluate", "gate"): _spec(
         "experiment-name",
         "run-id",
+        "child-run-name",
         "thresholds-file",
         required_inputs=("mlflow-url", "experiment-name", "thresholds-file"),
     ),

--- a/outer-loop/src/aip/outer/evaluate.py
+++ b/outer-loop/src/aip/outer/evaluate.py
@@ -21,6 +21,7 @@ from .util import (
     github_output,
     github_step_summary,
     load_yaml_file,
+    run_display_name,
 )
 
 app = typer.Typer()
@@ -55,6 +56,7 @@ def gate(
     experiment_name: Annotated[str, typer.Option("--experiment-name")],
     thresholds_file: Annotated[str, typer.Option("--thresholds-file")],
     run_id: Annotated[Optional[str], typer.Option("--run-id", callback=empty_string_to_none)] = None,
+    child_run_name: Annotated[Optional[str], typer.Option("--child-run-name", callback=empty_string_to_none)] = None,
     token: Annotated[Optional[str], typer.Option("--token", callback=empty_string_to_none)] = None,
     expires_on: Annotated[Optional[str], typer.Option("--expires-on", callback=empty_string_to_none)] = None,
 ):
@@ -64,6 +66,10 @@ def gate(
     Reads metric thresholds from a YAML config file, fetches metrics from MLFlow
     for the specified run (or the latest run in the experiment), and outputs
     pass/fail plus a Markdown summary table.
+
+    When --child-run-name is supplied, --run-id is treated as the parent (pipeline)
+    run and the named child job is evaluated instead.  This matches the inner-loop
+    'waitfor job' output, which returns the parent run ID.
 
     Thresholds YAML format:
       accuracy: {min: 0.85}
@@ -79,9 +85,17 @@ def gate(
     if not thresholds_file:
         typer.echo("[evaluate gate] ERROR: --thresholds-file is required", err=True)
         raise typer.Exit(1)
+    if child_run_name and not run_id:
+        typer.echo(
+            "[evaluate gate] ERROR: --child-run-name requires --run-id (the parent run)",
+            err=True,
+        )
+        raise typer.Exit(1)
 
     typer.echo(f"[evaluate gate] Experiment: {experiment_name}")
     typer.echo(f"[evaluate gate] Run ID: {run_id or '(latest)'}")
+    if child_run_name:
+        typer.echo(f"[evaluate gate] Child run name: {child_run_name!r}")
     typer.echo(f"[evaluate gate] Thresholds file: {thresholds_file}")
 
     thresholds = load_yaml_file(thresholds_file, "thresholds")
@@ -91,7 +105,10 @@ def gate(
     client = create_mlflow_client(mlflow_url, credential)
 
     # Resolve run ID — use latest run in experiment if not specified
-    if run_id:
+    if run_id and child_run_name:
+        actual_run_id = _resolve_child_run_id(client, experiment_name, run_id, child_run_name)
+        typer.echo(f"[evaluate gate] Resolved child run: {actual_run_id}")
+    elif run_id:
         actual_run_id = run_id
     else:
         runs = client.get_experiment_runs(experiment_name, max_results=1)
@@ -132,9 +149,15 @@ def gate(
     typer.echo(f"[evaluate gate] Overall result: {result.upper()}")
 
     # Build Markdown summary table
+    run_line = f"**Experiment:** `{experiment_name}`  **Run:** `{actual_run_id}`"
+    if child_run_name:
+        run_line = (
+            f"**Experiment:** `{experiment_name}`  **Parent run:** `{run_id}`  "
+            f"**Child run:** `{child_run_name}` (`{actual_run_id}`)"
+        )
     summary_lines = [
         f"## Evaluation Gate — {result.upper()}",
-        f"**Experiment:** `{experiment_name}`  **Run:** `{actual_run_id}`",
+        run_line,
         "",
         "| Metric | Actual | Threshold | Status |",
         "|--------|--------|-----------|--------|",
@@ -150,12 +173,47 @@ def gate(
 
     github_output({
         "result": result,
+        "resolved-run-id": actual_run_id,
         "summary": summary,
     })
 
     if not passed:
         typer.echo("[evaluate gate] Gate FAILED — exiting with code 1")
         raise typer.Exit(1)
+
+
+def _resolve_child_run_id(
+    client, experiment_name: str, parent_run_id: str, child_run_name: str
+) -> str:
+    """Return the run ID of the uniquely named child of ``parent_run_id``."""
+    children = client.get_child_runs(experiment_name, parent_run_id)
+    if not children:
+        typer.echo(
+            f"[evaluate gate] ERROR: run '{parent_run_id}' has no child runs. "
+            "Omit --child-run-name to evaluate this run directly.",
+            err=True,
+        )
+        raise typer.Exit(1)
+
+    matches = [c for c in children if run_display_name(c) == child_run_name]
+    if not matches:
+        available = ", ".join(sorted({run_display_name(c) for c in children if run_display_name(c)}))
+        typer.echo(
+            f"[evaluate gate] ERROR: no child run named {child_run_name!r} under run "
+            f"'{parent_run_id}'. Available child runs: {available or '(unnamed)'}",
+            err=True,
+        )
+        raise typer.Exit(1)
+    if len(matches) > 1:
+        matched_ids = ", ".join(c["run_id"] for c in matches)
+        typer.echo(
+            f"[evaluate gate] ERROR: {len(matches)} child runs named {child_run_name!r} "
+            f"under run '{parent_run_id}': {matched_ids}. "
+            "Pass the exact child run ID with --run-id instead.",
+            err=True,
+        )
+        raise typer.Exit(1)
+    return matches[0]["run_id"]
 
 
 # ---------------------------------------------------------------------------

--- a/outer-loop/src/aip/outer/util.py
+++ b/outer-loop/src/aip/outer/util.py
@@ -27,6 +27,9 @@ from azure.identity import DefaultAzureCredential
 AML_SCOPE = "https://ml.azure.com/.default"
 MANAGEMENT_SCOPE = "https://management.azure.com/.default"
 
+# Proxy run listing is unpaged, so child lookups fetch a single large page.
+CHILD_RUN_SEARCH_LIMIT = 1000
+
 
 # ---------------------------------------------------------------------------
 # MLFlow backend protocol
@@ -65,6 +68,19 @@ class MLFlowBackend(Protocol):
         """Return comparison data for multiple runs in an experiment.
 
         ``run_ids`` takes precedence over name-based filtering when supplied.
+        """
+        ...
+
+    def get_child_runs(
+        self,
+        experiment_name: str,
+        parent_run_id: str,
+        child_run_name: Optional[str] = None,
+    ) -> list[dict]:
+        """Return the child runs of ``parent_run_id``, most recent first.
+
+        If ``child_run_name`` is supplied, only children whose display name
+        matches exactly are returned.
         """
         ...
 
@@ -219,11 +235,27 @@ class MLFlowProxyClient:
             raise
         runs = data.get("runs", [])
         if child_run_name and not run_ids:
-            parent_runs = [run for run in runs if _run_name(run) == run_name]
-            return _select_child_runs(runs, parent_runs, child_run_name)
+            parent_ids = {
+                run["run_id"] for run in runs if run_display_name(run) == run_name
+            }
+            return _select_child_runs(runs, parent_ids, child_run_name)
         if run_name and not run_ids:
             runs = [r for r in runs if r.get("tags", {}).get("mlflow.runName") == run_name]
         return runs
+
+    def get_child_runs(
+        self,
+        experiment_name: str,
+        parent_run_id: str,
+        child_run_name: Optional[str] = None,
+    ) -> list[dict]:
+        """Return the child runs of ``parent_run_id``, optionally filtered by display name.
+
+        The proxy exposes no parent-scoped endpoint, so children are selected
+        client-side from the experiment run list.
+        """
+        runs = self.get_experiment_runs(experiment_name, max_results=CHILD_RUN_SEARCH_LIMIT)
+        return _select_child_runs(runs, {parent_run_id}, child_run_name)
 
     def get_run_artifacts(self, run_id: str) -> list[dict]:
         """List artifacts for a run."""
@@ -252,7 +284,7 @@ def _azureml_uri_to_https(uri: str) -> str:
     return "https://" + uri[len("azureml://"):]
 
 
-def _run_name(run: dict) -> str:
+def run_display_name(run: dict) -> str:
     """Return the MLflow run name from the standard field or compatibility tag."""
     return run.get("run_name") or run.get("tags", {}).get("mlflow.runName", "")
 
@@ -266,14 +298,13 @@ def _parent_run_id(run: dict) -> str:
 
 
 def _select_child_runs(
-    runs: list[dict], parent_runs: list[dict], child_run_name: str
+    runs: list[dict], parent_ids: set[str], child_run_name: Optional[str] = None
 ) -> list[dict]:
-    """Select named child runs of the supplied parent runs."""
-    parent_ids = {run["run_id"] for run in parent_runs}
+    """Select child runs of the supplied parent run IDs, optionally by display name."""
     return [
         run for run in runs
         if _parent_run_id(run) in parent_ids
-        and _run_name(run) == child_run_name
+        and (child_run_name is None or run_display_name(run) == child_run_name)
     ]
 
 
@@ -374,7 +405,7 @@ class AzureMLBackend:
             page_runs = runs_data.get("runs", [])
             normalized_runs = (self._normalize_run(run) for run in page_runs)
             if run_name:
-                runs.extend(run for run in normalized_runs if _run_name(run) == run_name)
+                runs.extend(run for run in normalized_runs if run_display_name(run) == run_name)
             else:
                 runs.extend(normalized_runs)
             if max_results is not None and len(runs) >= max_results:
@@ -411,8 +442,19 @@ class AzureMLBackend:
         if child_run_name:
             parent_runs = self.get_experiment_runs(experiment_name, max_results=None, run_name=run_name)
             all_runs = self.get_experiment_runs(experiment_name, max_results=None)
-            return _select_child_runs(all_runs, parent_runs, child_run_name)
+            parent_ids = {run["run_id"] for run in parent_runs}
+            return _select_child_runs(all_runs, parent_ids, child_run_name)
         return self.get_experiment_runs(experiment_name, max_results=100, run_name=run_name)
+
+    def get_child_runs(
+        self,
+        experiment_name: str,
+        parent_run_id: str,
+        child_run_name: Optional[str] = None,
+    ) -> list[dict]:
+        """Return the child runs of ``parent_run_id``, optionally filtered by display name."""
+        runs = self.get_experiment_runs(experiment_name, max_results=None)
+        return _select_child_runs(runs, {parent_run_id}, child_run_name)
 
     def get_run_artifacts(self, run_id: str) -> list[dict]:
         """List artifacts for a run."""
@@ -482,7 +524,7 @@ def github_output(outputs: dict[str, str]) -> None:
     """
     env_file = os.environ.get("GITHUB_OUTPUT")
     if env_file:
-        with open(env_file, "a") as f:
+        with open(env_file, "a", encoding="utf-8") as f:
             for key, value in outputs.items():
                 str_value = str(value)
                 if "\n" in str_value:
@@ -496,7 +538,7 @@ def github_step_summary(markdown: str) -> None:
     """Append markdown content to the GitHub step summary."""
     env_file = os.environ.get("GITHUB_STEP_SUMMARY")
     if env_file:
-        with open(env_file, "a") as f:
+        with open(env_file, "a", encoding="utf-8") as f:
             f.write(markdown + "\n")
     else:
         # Fallback: print to stdout when not running in GitHub Actions

--- a/outer-loop/test_outer.py
+++ b/outer-loop/test_outer.py
@@ -827,6 +827,46 @@ class TestAzureMLBackend:
             (('my-exp',), {"max_results": None}),
         ]
 
+    def test_get_child_runs_selects_children_of_parent(self):
+        backend = self._make_backend()
+        all_runs = [
+            {"run_id": "pipeline-1", "run_name": "daily-pipeline", "tags": {}},
+            {
+                "run_id": "evaluate-1",
+                "run_name": "evaluate_test",
+                "parent_run_id": "pipeline-1",
+                "tags": {},
+            },
+            {
+                "run_id": "train-1",
+                "run_name": "train",
+                "tags": {"mlflow.parentRunId": "pipeline-1"},
+            },
+            {
+                "run_id": "evaluate-2",
+                "run_name": "evaluate_test",
+                "parent_run_id": "pipeline-2",
+                "tags": {},
+            },
+        ]
+        backend.get_experiment_runs = MagicMock(return_value=all_runs)
+
+        result = backend.get_child_runs("my-exp", "pipeline-1")
+
+        assert [run["run_id"] for run in result] == ["evaluate-1", "train-1"]
+        backend.get_experiment_runs.assert_called_once_with("my-exp", max_results=None)
+
+    def test_get_child_runs_filters_by_child_run_name(self):
+        backend = self._make_backend()
+        backend.get_experiment_runs = MagicMock(return_value=[
+            {"run_id": "evaluate-1", "run_name": "evaluate_test", "parent_run_id": "pipeline-1"},
+            {"run_id": "train-1", "run_name": "train", "parent_run_id": "pipeline-1"},
+        ])
+
+        result = backend.get_child_runs("my-exp", "pipeline-1", child_run_name="evaluate_test")
+
+        assert [run["run_id"] for run in result] == ["evaluate-1"]
+
     def test_normalize_run_preserves_azureml_parent_run_id(self):
         normalized = AzureMLBackend._normalize_run({
             "info": {
@@ -910,6 +950,31 @@ class TestMLFlowProxyClientRunNameFilter:
         runs = client.compare_runs("my-exp", run_name="target")
 
         assert [r["run_id"] for r in runs] == ["r1"]
+
+    def test_get_child_runs_selects_named_children_of_parent(self):
+        client = self._make_client()
+        client._session.get.return_value = MagicMock(
+            raise_for_status=lambda: None,
+            json=lambda: {"runs": [
+                {"run_id": "pipeline-1", "tags": {"mlflow.runName": "daily-pipeline"}},
+                {"run_id": "evaluate-1", "tags": {
+                    "mlflow.runName": "evaluate_test",
+                    "mlflow.parentRunId": "pipeline-1",
+                }},
+                {"run_id": "train-1", "tags": {
+                    "mlflow.runName": "train",
+                    "mlflow.parentRunId": "pipeline-1",
+                }},
+                {"run_id": "evaluate-2", "tags": {
+                    "mlflow.runName": "evaluate_test",
+                    "mlflow.parentRunId": "pipeline-2",
+                }},
+            ]},
+        )
+
+        runs = client.get_child_runs("my-exp", "pipeline-1", child_run_name="evaluate_test")
+
+        assert [r["run_id"] for r in runs] == ["evaluate-1"]
 
 
 # =============================================================================
@@ -999,6 +1064,129 @@ class TestCompareCandidatesRunName:
         mock_client.compare_runs.assert_called_once_with(
             "my-exp", run_ids=None, run_name=None, child_run_name=None
         )
+
+
+# =============================================================================
+# evaluate gate CLI — child-run-name resolution
+# =============================================================================
+
+
+class TestGateChildRunResolution:
+    """CLI-level tests for --child-run-name in evaluate gate."""
+
+    THRESHOLDS_YAML = "accuracy:\n  min: 0.80\n"
+
+    def _run_gate(self, extra_args, children=None, metrics=None):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            f.write(self.THRESHOLDS_YAML)
+            tmp = f.name
+        try:
+            mock_client = MagicMock()
+            mock_client.get_child_runs.return_value = children or []
+            mock_client.get_run_metrics.return_value = metrics or {"accuracy": 0.9}
+            with (
+                patch("aip.outer.evaluate.create_mlflow_client", return_value=mock_client),
+                patch("aip.outer.evaluate.get_credential", return_value=MagicMock()),
+            ):
+                result = runner.invoke(
+                    evaluate_app,
+                    [
+                        "gate",
+                        "--mlflow-url", "https://proxy.example.com",
+                        "--experiment-name", "my-exp",
+                        "--thresholds-file", tmp,
+                    ] + extra_args,
+                )
+                return result, mock_client
+        finally:
+            os.unlink(tmp)
+
+    def test_child_run_name_resolves_to_child_run_id(self):
+        children = [
+            {"run_id": "c1", "run_name": "prep_data", "parent_run_id": "parent-1"},
+            {"run_id": "c2", "run_name": "evaluate_test", "parent_run_id": "parent-1"},
+        ]
+        result, mock_client = self._run_gate(
+            ["--run-id", "parent-1", "--child-run-name", "evaluate_test"], children
+        )
+
+        assert result.exit_code == 0
+        mock_client.get_child_runs.assert_called_once_with("my-exp", "parent-1")
+        mock_client.get_run_metrics.assert_called_once_with("c2")
+
+    def test_child_run_name_matches_run_name_tag(self):
+        children = [
+            {"run_id": "c1", "tags": {"mlflow.runName": "evaluate_test"}},
+        ]
+        result, mock_client = self._run_gate(
+            ["--run-id", "parent-1", "--child-run-name", "evaluate_test"], children
+        )
+
+        assert result.exit_code == 0
+        mock_client.get_run_metrics.assert_called_once_with("c1")
+
+    def test_run_id_without_child_run_name_is_used_directly(self):
+        result, mock_client = self._run_gate(["--run-id", "run-abc"])
+
+        assert result.exit_code == 0
+        mock_client.get_child_runs.assert_not_called()
+        mock_client.get_run_metrics.assert_called_once_with("run-abc")
+
+    def test_child_run_name_without_run_id_is_rejected(self):
+        result, mock_client = self._run_gate(["--child-run-name", "evaluate_test"])
+
+        assert result.exit_code == 1
+        assert "requires --run-id" in result.stderr
+        mock_client.get_child_runs.assert_not_called()
+        mock_client.get_run_metrics.assert_not_called()
+
+    def test_unknown_child_run_name_lists_available_names(self):
+        children = [
+            {"run_id": "c1", "run_name": "prep_data"},
+            {"run_id": "c2", "run_name": "train_model"},
+        ]
+        result, mock_client = self._run_gate(
+            ["--run-id", "parent-1", "--child-run-name", "evaluate_test"], children
+        )
+
+        assert result.exit_code == 1
+        assert "no child run named 'evaluate_test'" in result.stderr
+        assert "prep_data, train_model" in result.stderr
+        mock_client.get_run_metrics.assert_not_called()
+
+    def test_parent_without_children_reports_clear_error(self):
+        result, mock_client = self._run_gate(
+            ["--run-id", "parent-1", "--child-run-name", "evaluate_test"], []
+        )
+
+        assert result.exit_code == 1
+        assert "has no child runs" in result.stderr
+        mock_client.get_run_metrics.assert_not_called()
+
+    def test_ambiguous_child_run_name_is_rejected(self):
+        children = [
+            {"run_id": "c1", "run_name": "evaluate_test"},
+            {"run_id": "c2", "run_name": "evaluate_test"},
+        ]
+        result, mock_client = self._run_gate(
+            ["--run-id", "parent-1", "--child-run-name", "evaluate_test"], children
+        )
+
+        assert result.exit_code == 1
+        assert "2 child runs named 'evaluate_test'" in result.stderr
+        assert "c1, c2" in result.stderr
+        mock_client.get_run_metrics.assert_not_called()
+
+    def test_resolved_run_id_is_written_to_github_output(self, tmp_path):
+        children = [{"run_id": "c2", "run_name": "evaluate_test"}]
+        output_file = tmp_path / "gh_output"
+        with patch.dict(os.environ, {"GITHUB_OUTPUT": str(output_file)}):
+            result, _ = self._run_gate(
+                ["--run-id", "parent-1", "--child-run-name", "evaluate_test"], children
+            )
+
+        assert result.exit_code == 0
+        assert "resolved-run-id=c2" in output_file.read_text(encoding="utf-8")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What
Evaluate Gate accepts child-run-name.

## Why
Inner-loop waitfor job emits run id. If this is a pipeline, it will be the parent run id.
To enable evaluating metrics on child-jobs of a pipeline run, now provide the child-run-name to do that.

## Changes
outer-loop Evaluate Gate + util.py

## Validation
-- tests passed
-- docker builds passed
