### PR TITLE
value-type in override-inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,6 +353,7 @@ jobs:
 | `file` | The YAML file to modify (changes are ephemeral — only within this workflow run) |
 | `path` | Dot-notation path to the property to overwrite (e.g., `environment`) |
 | `set-value` | The new value — here, the freshly deployed environment reference |
+| `value-type` | How to interpret `set-value`: `string` (quoted, current default), `auto` (YAML type inference) or `raw` (a yq expression). Leaving it unset is deprecated and logs a warning |
 
 > **Ref:** [GitHub Actions quickstart](https://docs.github.com/en/actions/quickstart) &middot; [Setting up secrets](https://docs.github.com/en/actions/security-for-github-actions/security-guides/using-secrets-in-github-actions)
 
@@ -462,6 +463,8 @@ Full reference: [changed-files/README.md](changed-files/README.md)
 ### override-inputs
 
 Overwrites a value in a YAML file using `yq`. Changes are ephemeral — they only persist within the current workflow run. Used to chain outputs from one step into the inputs of another (e.g., pinning a component to the environment version that was just deployed).
+
+The optional `value-type` input controls how `set-value` is written: `string` writes a quoted string (`"45"`), `auto` infers the YAML type (`45` as an integer, `true` as a boolean), and `raw` treats `set-value` as a yq expression. The default is `string`, but leaving `value-type` unset is deprecated and logs a warning — a future major release will default to `auto`.
 
 Full reference: [override-inputs/README.md](override-inputs/README.md)
 

--- a/override-inputs/README.md
+++ b/override-inputs/README.md
@@ -4,11 +4,27 @@ Override a value in a YAML file using yq. Changes are ephemeral within the job c
 
 ## Inputs
 
-| Input | Description | Required |
-|-------|-------------|----------|
-| `file` | Path to the YAML file to modify | Yes |
-| `path` | Dot-notation path to the property (e.g., `inputs.threshold`, `jobs.inference.component`) | Yes |
-| `set-value` | The new value to set | Yes |
+| Input | Description | Required | Default |
+|-------|-------------|----------|---------|
+| `file` | Path to the YAML file to modify | Yes | |
+| `path` | Dot-notation path to the property (e.g., `inputs.threshold`, `jobs.inference.component`) | Yes | |
+| `set-value` | The new value to set | Yes | |
+| `value-type` | How to interpret `set-value`: `auto`, `string` or `raw` (see [Value types](#value-types)) | No | `string` |
+
+## Value types
+
+| `value-type` | Behaviour | `set-value: 45` writes |
+|--------------|-----------|------------------------|
+| `string` (current default) | The value is always written as a quoted string | `threshold: "45"` |
+| `auto` | The value is parsed as YAML, so numbers, booleans and strings keep their natural type | `threshold: 45` |
+| `raw` | The value is a yq expression, evaluated as-is | `threshold: 45` |
+
+Notes:
+
+- Leaving `value-type` unset is deprecated. It currently resolves to `string` and logs a warning; a future major release will change the default to `auto`. Set it explicitly to pin the behaviour you want.
+- With `auto`, a value containing a colon followed by a space (e.g. `key: value`) is parsed as a nested mapping. Use `string` when the value must stay a scalar.
+- With `auto`, references such as `azureml:testcomp:4` remain strings, since there is no colon-space.
+- `raw` inserts `set-value` directly into the yq expression, so it must only be used with trusted values.
 
 ## Usage Examples
 
@@ -21,6 +37,31 @@ Override a value in a YAML file using yq. Changes are ephemeral within the job c
     file: ./pipeline.yaml
     path: inputs.threshold
     set-value: 45
+    value-type: auto   # writes 45, not "45"
+```
+
+### Override a value that must stay a string
+
+```yaml
+- name: Override version label
+  uses: equinor/ai-platform-actions/override-inputs@main
+  with:
+    file: ./pipeline.yaml
+    path: inputs.version_label
+    set-value: 1.0
+    value-type: string
+```
+
+### Override using a yq expression
+
+```yaml
+- name: Override tag with commit sha
+  uses: equinor/ai-platform-actions/override-inputs@main
+  with:
+    file: ./pipeline.yaml
+    path: tags.commit
+    set-value: strenv(GITHUB_SHA)
+    value-type: raw
 ```
 
 ### Override a component version
@@ -32,6 +73,7 @@ Override a value in a YAML file using yq. Changes are ephemeral within the job c
     file: ./pipeline.yaml
     path: jobs.inference.component
     set-value: azureml:testcomp:4
+    value-type: string
 ```
 
 ### Override compute target
@@ -43,13 +85,14 @@ Override a value in a YAML file using yq. Changes are ephemeral within the job c
     file: ./pipeline.yaml
     path: settings.default_compute
     set-value: azureml:unified-gpu
+    value-type: string
 ```
 
 ## Notes
 
 - Uses `yq` for in-place YAML modification
 - Changes only persist within the current job context
-- Path uses dot-notation to navigate the YAML structure
+- Path uses dot-notation to navigate the YAML structure, restricted to keys and numeric indices (e.g. `jobs.inference.component`, `inputs.items[0]`)
 
 ## Related Documentation
 

--- a/override-inputs/action.yaml
+++ b/override-inputs/action.yaml
@@ -11,15 +11,86 @@ inputs:
   set-value:
     description: 'The new value to set'
     required: true
+  value-type:
+    description: 'How to interpret set-value: auto (YAML type inference), string (always a quoted string), raw (set-value is a yq expression). Defaults to string; leaving it unset is deprecated.'
+    required: false
+    default: ''
 
 runs:
   using: "composite"
   steps:
-    - name: Override Value
+    - name: Summary
       shell: bash
+      env:
+        OVR_FILE: ${{ inputs.file }}
+        OVR_PATH: ${{ inputs.path }}
+        OVR_VALUE: ${{ inputs.set-value }}
+        OVR_TYPE: ${{ inputs.value-type }}
       run: |
-        if [ ! -f "${{ inputs.file }}" ]; then
-          echo "❌ Error: File not found: ${{ inputs.file }}"
+        set -euo pipefail
+        echo "Override: .${OVR_PATH} = ${OVR_VALUE} (value-type: ${OVR_TYPE:-string, defaulted}) in ${OVR_FILE}"
+
+    - name: Validate Inputs
+      id: validate
+      shell: bash
+      env:
+        OVR_FILE: ${{ inputs.file }}
+        OVR_PATH: ${{ inputs.path }}
+        OVR_VALUE: ${{ inputs.set-value }}
+        OVR_TYPE: ${{ inputs.value-type }}
+      run: |
+        set -euo pipefail
+
+        if [ ! -f "$OVR_FILE" ]; then
+          echo "❌ File not found: ${OVR_FILE}"
           exit 1
         fi
-        yq -i '.${{ inputs.path }} = "${{ inputs.set-value }}"' "${{ inputs.file }}"
+
+        path_re='^[A-Za-z_][A-Za-z0-9_-]*(\[[0-9]+\]|\.[A-Za-z_][A-Za-z0-9_-]*)*$'
+        if [[ ! "$OVR_PATH" =~ $path_re ]]; then
+          echo "❌ Invalid path: ${OVR_PATH}. Expected dot-notation, e.g. inputs.threshold or jobs.inference.component"
+          exit 1
+        fi
+
+        if [ -z "$OVR_TYPE" ]; then
+          OVR_TYPE=string
+          echo "::warning::override-inputs: value-type not set, defaulting to 'string' (quoted). A future major release will default to 'auto' (YAML type inference). Set value-type explicitly to keep current behaviour."
+        fi
+
+        case "$OVR_TYPE" in
+          auto)   value_expr='env(OVR_VALUE)' ;;
+          string) value_expr='strenv(OVR_VALUE)' ;;
+          raw)    value_expr="$OVR_VALUE" ;;
+          *)
+            echo "❌ Invalid value-type: ${OVR_TYPE}. Expected one of: auto, string, raw"
+            exit 1
+            ;;
+        esac
+
+        {
+          echo "value-expr<<OVR_EXPR_EOF"
+          echo "$value_expr"
+          echo "OVR_EXPR_EOF"
+        } >> "$GITHUB_OUTPUT"
+
+        echo "✅ Validated ${OVR_FILE}, path .${OVR_PATH}, value-type ${OVR_TYPE}"
+
+    - name: Override Value
+      shell: bash
+      env:
+        OVR_FILE: ${{ inputs.file }}
+        OVR_PATH: ${{ inputs.path }}
+        OVR_VALUE: ${{ inputs.set-value }}
+        OVR_EXPR: ${{ steps.validate.outputs.value-expr }}
+      run: |
+        set -euo pipefail
+        yq -i ".${OVR_PATH} = ${OVR_EXPR}" "$OVR_FILE"
+
+    - name: Result
+      shell: bash
+      env:
+        OVR_FILE: ${{ inputs.file }}
+        OVR_PATH: ${{ inputs.path }}
+      run: |
+        set -euo pipefail
+        echo "✅ ${OVR_FILE}: .${OVR_PATH} = $(yq ".${OVR_PATH}" "$OVR_FILE") (type: $(yq ".${OVR_PATH} | type" "$OVR_FILE"))"


### PR DESCRIPTION
## What
Allow value-type argument in override-inputs.

## Why
With value-type: auto, it is possible to set integer, float or boolean values without adding quotes.
Without value-type, or if setting it to string, the overridden path in the file will have double quoted delimiters.
If not setting value-type, emits a log warning that not using value-type is deprecated.
In future (next main version), default value-type will be auto.

## Change
the override-inputs action

## Validation
- tests passed
- docker builds passed
