### PR TITLE
Support workspaces where shared access key disabled

### DIFF
--- a/.github/skills/create-inner-loops/SKILL.md
+++ b/.github/skills/create-inner-loops/SKILL.md
@@ -29,6 +29,12 @@ has been setup with Federated Credentials toward this repository and to the name
 The UAMI is expected to have the Contributor on the resource group with the AML workspace,
 or at least "AI Developer" on the AML workspace, and at least "Registry User" on the Registry.
 
+If the workspace storage account has shared key access disabled (`allowSharedKeyAccess: false`),
+the UAMI additionally needs "Storage Blob Data Contributor" on that storage account, and the
+Get Token step must also produce a storage-scoped token
+(`az account get-access-token --resource https://storage.azure.com`) that is passed to every
+deploy step as the `storage-token` input. Do not add this unless shared key access is disabled.
+
 ## Asset Dependencies
 
 ML assets should always be deployed accroding to their dependencies.

--- a/docs/tests-overview.md
+++ b/docs/tests-overview.md
@@ -6,9 +6,9 @@ This repository has two independently runnable Python test suites, one for each 
 
 | Area | Test modules | Collected pytest items | Primary test level |
 | --- | ---: | ---: | --- |
-| Inner loop | 6 | 1,409 | Action-contract matrix and unit tests |
+| Inner loop | 6 | 1,449 | Action-contract matrix and unit tests |
 | Outer loop | 2 | 87 | Action contracts, unit tests, and command-level tests |
-| Total | 8 | 1,496 | Isolated/local tests |
+| Total | 8 | 1,536 | Isolated/local tests |
 
 The item count is from `pytest --collect-only` on 2026-08-05. It is higher than the number of test functions because the inner-loop contract tests are heavily parameterized across commands and inputs.
 
@@ -29,11 +29,11 @@ The inner-loop action manages Azure ML asset and endpoint operations. Its test s
 
 | Test module | Items | What it verifies |
 | --- | ---: | --- |
-| [`inner-loop/test_action_contract.py`](../inner-loop/test_action_contract.py) | 1,326 | The complete 30-command action matrix: all applicable action inputs are forwarded, non-applicable and unsupported inputs are rejected without leaking values, required inputs and aliases are validated, blanks are omitted, and legacy invocation remains compatible. It also verifies `action.yaml` exposure, Docker/direct entrypoints, lazy import behavior, and exact agreement between the action contract and the Typer/Click command tree. |
+| [`inner-loop/test_action_contract.py`](../inner-loop/test_action_contract.py) | 1,359 | The complete 30-command action matrix: all applicable action inputs are forwarded, non-applicable and unsupported inputs are rejected without leaking values, required inputs and aliases are validated, blanks are omitted, and legacy invocation remains compatible. It also verifies `action.yaml` exposure, Docker/direct entrypoints, lazy import behavior, and exact agreement between the action contract and the Typer/Click command tree. |
 | [`inner-loop/test_arm.py`](../inner-loop/test_arm.py) | 38 | ARM URL construction, API-version use, pagination, registry resource-group discovery, error redaction, integer-version parsing and selection, archived-version counting, and archived-container recovery behavior. Requests are handled by a recording fake transport. |
 | [`inner-loop/test_batch_lifecycle.py`](../inner-loop/test_batch_lifecycle.py) | 9 | Batch endpoint and deployment creation, tag handling, GitHub outputs, idempotent default-deployment changes, concurrent-change protection, update verification, promotion/rollback, and pinned deployment invocation. |
 | [`inner-loop/test_deploy_versioning.py`](../inner-loop/test_deploy_versioning.py) | 3 | Data-asset version assignment from existing workspace versions, ignoring non-integer versions, and the no-existing-asset case. |
-| [`inner-loop/test_util.py`](../inner-loop/test_util.py) | 32 | Credential scope routing, `GITHUB_OUTPUT` writing, safe tag parsing, and Azure ML asset-reference parsing for simple, workspace, and registry forms. |
+| [`inner-loop/test_util.py`](../inner-loop/test_util.py) | 39 | Credential scope routing for ARM, Azure ML, and storage tokens, the denied-storage-request hint, `GITHUB_OUTPUT` writing, safe tag parsing, and Azure ML asset-reference parsing for simple, workspace, and registry forms. |
 | [`inner-loop/test_waitfor_job.py`](../inner-loop/test_waitfor_job.py) | 1 | Separate routing of ARM and Azure ML tokens for job polling. |
 
 The contract matrix is the dominant source of inner-loop depth. It enumerates command/input combinations rather than sampling a small subset, so a new input, command, or CLI option has a high chance of breaking a focused contract assertion.

--- a/how-to-use.md
+++ b/how-to-use.md
@@ -131,6 +131,31 @@ jobs:
 
 The `aml-token` input is only required for job operations, but it is safe to pass it for all subjects in a shared matrix workflow.
 
+## Optional: Storage Accounts With Shared Key Access Disabled
+
+Deploying an asset that has a local path uploads artifacts to the workspace storage account. Normally the Azure ML SDK uses an account key for that upload, so no extra configuration is needed.
+
+If your workspace storage account is configured with `allowSharedKeyAccess: false`, the upload must authenticate with Entra ID instead. Add a storage-scoped token to the token step and pass it to the action:
+
+```yaml
+      - name: Get access tokens
+        id: get-token
+        shell: bash
+        run: |
+          # ... existing token lines
+          STORAGE_TOKEN=$(az account get-access-token --resource https://storage.azure.com --query accessToken --output tsv)
+          echo "::add-mask::$STORAGE_TOKEN"
+          echo "storage-token=$STORAGE_TOKEN" >> "$GITHUB_OUTPUT"
+
+      - name: Deploy changed asset
+        uses: equinor/ai-platform-actions/inner-loop@main
+        with:
+          storage-token: ${{ steps.get-token.outputs.storage-token }}
+          # ... remaining inputs
+```
+
+The `storage-token` input is accepted by every `deploy` subject, and the workflow identity needs the **Storage Blob Data Contributor** role on that storage account. When the token is missing, the action prints this guidance as soon as a blob request is denied.
+
 ## Customization
 
 - You can add additional steps to deploy only specific asset types (e.g., only environments or only components) by filtering the changed files output.

--- a/inner-loop/EXAMPLES.md
+++ b/inner-loop/EXAMPLES.md
@@ -290,6 +290,35 @@ python main.py deploy component \
   --filepath "./components/my-component.yaml"
 ```
 
+### Storage Account Without Shared Key Access
+
+Only needed when the workspace storage account has `allowSharedKeyAccess: false`.
+The identity also needs the `Storage Blob Data Contributor` role on that account.
+
+```yaml
+- name: Get access tokens
+  id: get-token
+  shell: bash
+  run: |
+    TOKEN=$(az account get-access-token --query accessToken --output tsv)
+    STORAGE_TOKEN=$(az account get-access-token --resource https://storage.azure.com --query accessToken --output tsv)
+    EXPIRES_ON=$(az account get-access-token --query expires_on --output tsv)
+    echo "::add-mask::$TOKEN"
+    echo "::add-mask::$STORAGE_TOKEN"
+    echo "token=$TOKEN" >> "$GITHUB_OUTPUT"
+    echo "storage-token=$STORAGE_TOKEN" >> "$GITHUB_OUTPUT"
+    echo "expires-on=$EXPIRES_ON" >> "$GITHUB_OUTPUT"
+
+- uses: ./inner-loop
+  with:
+    verb: deploy
+    subject: component
+    token: ${{ steps.get-token.outputs.token }}
+    expires-on: ${{ steps.get-token.outputs.expires-on }}
+    storage-token: ${{ steps.get-token.outputs.storage-token }}
+    # ... other parameters
+```
+
 ## File Structure
 
 ```

--- a/inner-loop/README.md
+++ b/inner-loop/README.md
@@ -100,6 +100,34 @@ The action supports two authentication methods:
    - Supports: Environment variables, Managed identity, Azure CLI, VS Code, Azure PowerShell, and more
    - Perfect for local testing and development
 
+### Storage accounts without shared key access
+
+Deploying an asset with a local path (data, model, component code, environment build context, job code snapshot) uploads artifacts to the workspace storage account. By default the Azure ML SDK fetches an account key for that upload, so no extra token is needed.
+
+If the storage account sets `allowSharedKeyAccess: false`, the upload authenticates with Entra ID instead and needs a storage-scoped token:
+
+```yaml
+- name: Get access tokens
+  id: get-token
+  shell: bash
+  run: |
+    TOKEN=$(az account get-access-token --query accessToken --output tsv)
+    STORAGE_TOKEN=$(az account get-access-token --resource https://storage.azure.com --query accessToken --output tsv)
+    EXPIRES_ON=$(az account get-access-token --query expires_on --output tsv)
+    echo "::add-mask::$TOKEN"
+    echo "::add-mask::$STORAGE_TOKEN"
+    echo "token=$TOKEN" >> "$GITHUB_OUTPUT"
+    echo "storage-token=$STORAGE_TOKEN" >> "$GITHUB_OUTPUT"
+    echo "expires-on=$EXPIRES_ON" >> "$GITHUB_OUTPUT"
+
+- uses: equinor/ai-platform-actions/inner-loop@main
+  with:
+    storage-token: ${{ steps.get-token.outputs.storage-token }}
+    # ... remaining inputs
+```
+
+The workflow identity also needs the **Storage Blob Data Contributor** role on the workspace storage account. When the action detects a denied blob request it prints this guidance before failing.
+
 ## Usage
 
 ### Deploy Data Asset
@@ -189,6 +217,8 @@ The action supports two authentication methods:
 ```
 
 **Note:** When token-based authentication is used, `deploy job`, `deploy sweep-job`, and `waitfor job` accept an `aml-token` with the `https://ml.azure.com/.default` scope. It is optional when `DefaultAzureCredential` is available locally.
+
+**Note:** Every `deploy` command also accepts an optional `storage-token` with the `https://storage.azure.com/.default` scope. It is only needed when the workspace storage account has shared key access disabled (`allowSharedKeyAccess: false`), because artifact upload then authenticates with Entra ID instead of an account key. See [Storage accounts without shared key access](#storage-accounts-without-shared-key-access).
 
 ### Deploy Online Endpoint
 
@@ -353,6 +383,7 @@ The waitfor verb polls Azure ML every 10 seconds (up to 30 minutes) until the sp
 | `token` | No* | Access token from Azure login action (*required for GitHub Actions) |
 | `expires-on` | No* | Token expiration timestamp from Azure login action (*required for GitHub Actions) |
 | `aml-token` | No | Access token with Azure ML scope for `deploy job`, `deploy sweep-job`, and `waitfor job`; optional when `DefaultAzureCredential` is available locally |
+| `storage-token` | No | Access token with Azure Storage scope (`https://storage.azure.com/.default`) for `deploy` commands; only needed when the workspace storage account has shared key access disabled |
 | `tenant-id` | No | Azure tenant ID (required for token-based auth) |
 | `subscription-id` | Yes | Azure subscription ID |
 | `resource-group` | Yes | Azure resource group name |

--- a/inner-loop/action.yaml
+++ b/inner-loop/action.yaml
@@ -17,6 +17,9 @@ inputs:
   aml-token:
     description: "Access token with Azure ML scope (https://ml.azure.com/.default) for deploy job, deploy sweep-job, and waitfor job. Optional when DefaultAzureCredential is available locally."
     required: false
+  storage-token:
+    description: "Access token with Azure Storage scope (https://storage.azure.com/.default) for deploy commands. Only needed when the workspace storage account has shared key access disabled."
+    required: false
   tenant-id:
     description: "Azure tenant ID"
     required: false
@@ -142,6 +145,7 @@ runs:
     INPUT_TOKEN: ${{ inputs.token }}
     INPUT_EXPIRES_ON: ${{ inputs.expires-on }}
     INPUT_AML_TOKEN: ${{ inputs.aml-token }}
+    INPUT_STORAGE_TOKEN: ${{ inputs.storage-token }}
     INPUT_TENANT_ID: ${{ inputs.tenant-id }}
     INPUT_SUBSCRIPTION_ID: ${{ inputs.subscription-id }}
     INPUT_RESOURCE_GROUP: ${{ inputs.resource-group }}

--- a/inner-loop/src/aip/inner/action_entrypoint.py
+++ b/inner-loop/src/aip/inner/action_entrypoint.py
@@ -16,6 +16,7 @@ ACTION_INPUTS = frozenset({
     "token",
     "expires-on",
     "aml-token",
+    "storage-token",
     "tenant-id",
     "subscription-id",
     "resource-group",
@@ -68,6 +69,7 @@ CLI_OPTIONS = {
     "token": "--token",
     "expires-on": "--expires-on",
     "aml-token": "--aml-token",
+    "storage-token": "--storage-token",
     "registry-name": "--registry-name",
     "tags": "--tags",
     "promote-stage": "--promote-stage",
@@ -150,8 +152,10 @@ def _spec(
     )
 
 
-_DEPLOY_YAML_OPTIONS = ("tags",)
-_DEPLOY_AML_OPTIONS = ("aml-token", "tags")
+# Every deploy command may upload artifacts, so all of them accept a storage-scoped token.
+_DEPLOY_STORAGE_OPTIONS = ("storage-token",)
+_DEPLOY_YAML_OPTIONS = _DEPLOY_STORAGE_OPTIONS + ("tags",)
+_DEPLOY_AML_OPTIONS = _DEPLOY_STORAGE_OPTIONS + ("aml-token", "tags")
 _SHARE_OPTIONS = ("registry-name", "tags", "promote-stage")
 _WAIT_OPTIONS = ("tags",)
 _WAIT_ENV = {"timeout-minutes": "TIMEOUT_MINUTES"}
@@ -173,7 +177,7 @@ COMMAND_SPECS = {
     ("deploy", "online-endpoint"): _spec("filepath", option_inputs=_DEPLOY_YAML_OPTIONS),
     ("deploy", "online-deployment"): _spec(
         "filepath",
-        option_inputs=("traffic-allocation", "tags"),
+        option_inputs=_DEPLOY_STORAGE_OPTIONS + ("traffic-allocation", "tags"),
     ),
     ("deploy", "batch-endpoint"): _spec("filepath", option_inputs=_DEPLOY_AML_OPTIONS),
     ("deploy", "batch-deployment"): _spec("filepath", option_inputs=_DEPLOY_AML_OPTIONS),
@@ -181,7 +185,8 @@ COMMAND_SPECS = {
         "job-ref",
         positional_aliases=("job-name",),
         required_inputs=("schedule-name", "cron-expression"),
-        option_inputs=("schedule-name", "cron-expression", "time-zone"),
+        option_inputs=_DEPLOY_STORAGE_OPTIONS
+        + ("schedule-name", "cron-expression", "time-zone"),
     ),
     ("share", "data"): _spec(
         "data-ref",
@@ -477,9 +482,9 @@ def main() -> None:
     os.environ.update(invocation.environment)
     sys.argv[1:] = invocation.argv
 
-    from .main import app
+    from .main import run
 
-    app()
+    run()
 
 
 if __name__ == "__main__":

--- a/inner-loop/src/aip/inner/deploy.py
+++ b/inner-loop/src/aip/inner/deploy.py
@@ -56,6 +56,7 @@ def data(
         filepath: str,
         token: Optional[str] = None,
         expires_on: Optional[int] = None,
+        storage_token: Annotated[Optional[str], typer.Option("--storage-token", callback=empty_string_to_none)] = None,
         tags: Annotated[
             Optional[str],
             typer.Option(help="Tags in the config file to use", callback=load_safe_tags),
@@ -73,7 +74,8 @@ def data(
         resource_group=resource_group,
         workspace_name=workspace_name,
         token=token,
-        expires_on=expires_on
+        expires_on=expires_on,
+        storage_token=storage_token
     )
 
     print("[deploy data] Loading data configuration from file")
@@ -124,6 +126,7 @@ def environment(
         filepath: str,
         token: Optional[str] = None,
         expires_on: Optional[int] = None,
+        storage_token: Annotated[Optional[str], typer.Option("--storage-token", callback=empty_string_to_none)] = None,
         tags: Annotated[
             Optional[str],
             typer.Option(help="Tags in the config file to use", callback=load_safe_tags),
@@ -149,7 +152,8 @@ def environment(
         resource_group=resource_group,
         workspace_name=workspace_name,
         token=token,
-        expires_on=expires_on
+        expires_on=expires_on,
+        storage_token=storage_token
     )
    
     print("[deploy environment] Creating or updating environment")
@@ -174,6 +178,7 @@ def component(
         filepath: str,
         token: Optional[str] = None,
         expires_on: Optional[int] = None,
+        storage_token: Annotated[Optional[str], typer.Option("--storage-token", callback=empty_string_to_none)] = None,
         tags: Annotated[
             Optional[str],
             typer.Option(help="Tags in the config file to use", callback=load_safe_tags),
@@ -206,7 +211,8 @@ def component(
         resource_group=resource_group,
         workspace_name=workspace_name,
         token=token,
-        expires_on=expires_on
+        expires_on=expires_on,
+        storage_token=storage_token
     )
 
     # Due to components being deployed has a "non-standard" version by default,
@@ -251,6 +257,7 @@ def model(
         filepath: str,
         token: Optional[str] = None,
         expires_on: Optional[int] = None,
+        storage_token: Annotated[Optional[str], typer.Option("--storage-token", callback=empty_string_to_none)] = None,
         tags: Annotated[
             Optional[str],
             typer.Option(help="Tags in the config file to use", callback=load_safe_tags),
@@ -268,7 +275,8 @@ def model(
         resource_group=resource_group,
         workspace_name=workspace_name,
         token=token,
-        expires_on=expires_on
+        expires_on=expires_on,
+        storage_token=storage_token
     )
 
     print("[deploy model] Loading model configuration from file")
@@ -301,6 +309,7 @@ def job(
         token: Optional[str] = None,
         expires_on: Optional[int] = None,
         aml_token: Annotated[Optional[str], typer.Option("--aml-token", callback=empty_string_to_none)] = None,
+        storage_token: Annotated[Optional[str], typer.Option("--storage-token", callback=empty_string_to_none)] = None,
         tags: Annotated[
             Optional[str],
             typer.Option(help="Tags in the config file to use", callback=load_safe_tags),
@@ -328,7 +337,8 @@ def job(
         workspace_name=workspace_name,
         token=token,
         expires_on=expires_on,
-        aml_token=aml_token
+        aml_token=aml_token,
+        storage_token=storage_token
     )
 
     print("[deploy job] Loading job configuration from file")
@@ -399,6 +409,7 @@ def sweep_job(
         token: Optional[str] = None,
         expires_on: Optional[int] = None,
         aml_token: Annotated[Optional[str], typer.Option("--aml-token", callback=empty_string_to_none)] = None,
+        storage_token: Annotated[Optional[str], typer.Option("--storage-token", callback=empty_string_to_none)] = None,
         experiment_name: Annotated[Optional[str], typer.Option("--experiment-name", callback=empty_string_to_none)] = None,
         tags: Annotated[
             Optional[str],
@@ -424,7 +435,8 @@ def sweep_job(
         workspace_name=workspace_name,
         token=token,
         expires_on=expires_on,
-        aml_token=aml_token
+        aml_token=aml_token,
+        storage_token=storage_token
     )
 
     print("[deploy sweep-job] Loading sweep job configuration from file")
@@ -463,6 +475,7 @@ def feature_set(
         filepath: str,
         token: Optional[str] = None,
         expires_on: Optional[int] = None,
+        storage_token: Annotated[Optional[str], typer.Option("--storage-token", callback=empty_string_to_none)] = None,
         tags: Annotated[
             Optional[str],
             typer.Option(help="Tags in the config file to use", callback=load_safe_tags),
@@ -487,7 +500,8 @@ def feature_set(
         resource_group=resource_group,
         workspace_name=workspace_name,
         token=token,
-        expires_on=expires_on
+        expires_on=expires_on,
+        storage_token=storage_token
     )
 
     print("[deploy feature-set] Loading data asset configuration from file")
@@ -532,6 +546,7 @@ def online_endpoint(
         filepath: str,
         token: Optional[str] = None,
         expires_on: Optional[int] = None,
+        storage_token: Annotated[Optional[str], typer.Option("--storage-token", callback=empty_string_to_none)] = None,
         tags: Annotated[
             Optional[str],
             typer.Option(help="Tags in the config file to use", callback=load_safe_tags),
@@ -552,6 +567,7 @@ def online_endpoint(
         workspace_name=workspace_name,
         token=token,
         expires_on=expires_on,
+        storage_token=storage_token,
     )
 
     print("[deploy online-endpoint] Loading endpoint configuration from file")
@@ -607,6 +623,7 @@ def online_deployment(
         ] = None,
         token: Optional[str] = None,
         expires_on: Optional[int] = None,
+        storage_token: Annotated[Optional[str], typer.Option("--storage-token", callback=empty_string_to_none)] = None,
         tags: Annotated[
             Optional[str],
             typer.Option(help="Tags in the config file to use", callback=load_safe_tags),
@@ -640,6 +657,7 @@ def online_deployment(
         workspace_name=workspace_name,
         token=token,
         expires_on=expires_on,
+        storage_token=storage_token,
     )
 
     if is_kubernetes:
@@ -734,6 +752,7 @@ def batch_endpoint(
             typer.Option(help="Tags in the config file to use", callback=load_safe_tags),
         ] = None,
         aml_token: Annotated[Optional[str], typer.Option("--aml-token", callback=empty_string_to_none)] = None,
+        storage_token: Annotated[Optional[str], typer.Option("--storage-token", callback=empty_string_to_none)] = None,
     ):
     """Create or update an Azure ML batch endpoint from a YAML definition."""
     print(f"[deploy batch-endpoint] Loading endpoint configuration from {filepath}")
@@ -748,6 +767,7 @@ def batch_endpoint(
         token=token,
         expires_on=int(expires_on) if expires_on else None,
         aml_token=aml_token,
+        storage_token=storage_token,
     )
     result = client.batch_endpoints.begin_create_or_update(endpoint).result()
 
@@ -772,6 +792,7 @@ def batch_deployment(
             typer.Option(help="Tags in the config file to use", callback=load_safe_tags),
         ] = None,
         aml_token: Annotated[Optional[str], typer.Option("--aml-token", callback=empty_string_to_none)] = None,
+        storage_token: Annotated[Optional[str], typer.Option("--storage-token", callback=empty_string_to_none)] = None,
     ):
     """Create or update a versioned Azure ML batch deployment from YAML."""
     print(f"[deploy batch-deployment] Loading deployment configuration from {filepath}")
@@ -788,6 +809,7 @@ def batch_deployment(
         token=token,
         expires_on=int(expires_on) if expires_on else None,
         aml_token=aml_token,
+        storage_token=storage_token,
     )
     result = client.batch_deployments.begin_create_or_update(deployment).result()
 
@@ -814,6 +836,7 @@ def schedule(
         time_zone: Annotated[Optional[str], typer.Option("--time-zone", )] = "UTC",
         token: Optional[str] = None,
         expires_on: Optional[int] = None,
+        storage_token: Annotated[Optional[str], typer.Option("--storage-token", callback=empty_string_to_none)] = None,
 ):
     print(f"[deploy schedule] Deploying Schedule")
     print(f"  Workspace: {workspace_name}")
@@ -830,6 +853,7 @@ def schedule(
         workspace_name=workspace_name,
         token=token,
         expires_on=expires_on,
+        storage_token=storage_token,
     )
 
     print("[deploy schedule] Instantiating Schedule")

--- a/inner-loop/src/aip/inner/main.py
+++ b/inner-loop/src/aip/inner/main.py
@@ -5,6 +5,7 @@ Routes to deploy.py or share.py based on the verb.
 """
 
 import logging
+import sys
 import typer
 from typing import Optional
 
@@ -21,6 +22,7 @@ from . import delete
 from . import rollback
 from . import invoke
 from . import promote
+from .util import storage_auth_hint
 
 app = typer.Typer()
 
@@ -33,5 +35,17 @@ app.add_typer(rollback.app, name="rollback")
 app.add_typer(invoke.app, name="invoke")
 app.add_typer(promote.app, name="promote")
 
+
+def run() -> None:
+    """Run the CLI, annotating failures that look like a denied storage request."""
+    try:
+        app()
+    except Exception as error:
+        hint = storage_auth_hint(error)
+        if hint:
+            print(hint, file=sys.stderr)
+        raise
+
+
 if __name__ == "__main__":
-    app()
+    run()

--- a/inner-loop/src/aip/inner/util.py
+++ b/inner-loop/src/aip/inner/util.py
@@ -16,35 +16,62 @@ from azure.core.credentials import AccessToken
 from azure.identity import DefaultAzureCredential
 
 AML_SCOPE = "https://ml.azure.com/.default"
+STORAGE_SCOPE = "https://storage.azure.com/.default"
+
+
+def _resource(scope: str) -> str:
+    """Reduce an OAuth scope to its bare resource, e.g. https://storage.azure.com"""
+    return scope.split("/.default", 1)[0].rstrip("/").lower()
+
+
+_AML_RESOURCE = _resource(AML_SCOPE)
+_STORAGE_RESOURCE = _resource(STORAGE_SCOPE)
+# Blob/ADLS clients sometimes request a per-account audience instead of the shared resource.
+_STORAGE_HOST_SUFFIXES = (".blob.core.windows.net", ".dfs.core.windows.net")
+
+
+def _is_storage_resource(resource: str) -> bool:
+    return resource == _STORAGE_RESOURCE or resource.endswith(_STORAGE_HOST_SUFFIXES)
 
 
 class Credential:
     """
     Credential wrapper for Azure SDK that handles Azure ML's scope requirements.
-    
+
     Azure ML operations (especially job submission) require tokens with the
-    https://ml.azure.com/.default scope. When this scope is requested, the
-    wrapper returns the dedicated AML token if provided.
+    https://ml.azure.com/.default scope, and artifact upload to a storage account
+    with shared key access disabled requires https://storage.azure.com/.default.
+    Scope-specific tokens are returned when supplied; any other scope falls back
+    to the ARM access token.
     """
-    def __init__(self, access_token: str, expires_on: int, aml_token: Optional[str] = None):
+    def __init__(self, access_token: str, expires_on: int, aml_token: Optional[str] = None,
+                 storage_token: Optional[str] = None):
         self._access_token = AccessToken(token=access_token, expires_on=expires_on)
         self._aml_token = AccessToken(token=aml_token, expires_on=expires_on) if aml_token else None
-    
+        self._storage_token = (
+            AccessToken(token=storage_token, expires_on=expires_on) if storage_token else None
+        )
+
     def get_token(self, *scopes: str, claims: str | None = None, 
                    tenant_id: str | None = None, enable_cae: bool = False, 
                    **kwargs) -> AccessToken:
-        if AML_SCOPE in scopes and self._aml_token:
-            return self._aml_token
+        for scope in scopes:
+            resource = _resource(scope)
+            if self._aml_token and resource == _AML_RESOURCE:
+                return self._aml_token
+            if self._storage_token and _is_storage_resource(resource):
+                return self._storage_token
         return self._access_token
 
 
 def get_workspace_client(subscription_id: str, resource_group: str, 
                          workspace_name: str, token: Optional[str] = None, 
                          expires_on: Optional[int] = None,
-                         aml_token: Optional[str] = None) -> MLClient:
+                         aml_token: Optional[str] = None,
+                         storage_token: Optional[str] = None) -> MLClient:
     """Create MLClient for workspace"""
     if token and expires_on:
-        credential = Credential(token, expires_on, aml_token)
+        credential = Credential(token, expires_on, aml_token, storage_token)
     else:
         credential = DefaultAzureCredential()
     return MLClient(
@@ -58,11 +85,12 @@ def get_registry_client(
         registry_name: str, 
         token: Optional[str] = None, 
         expires_on: Optional[int] = None,
-        aml_token: Optional[str] = None
+        aml_token: Optional[str] = None,
+        storage_token: Optional[str] = None
     ) -> MLClient:
     """Create MLClient for registry"""
     if token and expires_on:
-        credential = Credential(token, expires_on, aml_token)
+        credential = Credential(token, expires_on, aml_token, storage_token)
     else:
         credential = DefaultAzureCredential()
     return MLClient(
@@ -122,6 +150,42 @@ def empty_string_to_none(value: Optional[str]) -> Optional[str]:
     if value is None or (isinstance(value, str) and value.strip() == ""):
         return None
     return value
+
+
+# Storage errors that can only mean the caller was refused at the blob endpoint.
+_STORAGE_AUTH_MARKERS = (
+    "keybasedauthenticationnotpermitted",
+    "authorizationpermissionmismatch",
+    "authorizationfailure",
+)
+# Generic auth errors that only point at storage when raised in a storage context.
+_AMBIGUOUS_AUTH_MARKERS = ("authenticationfailed", "invalidauthenticationinfo")
+_STORAGE_CONTEXT_MARKERS = ("blob", "storage", "datastore")
+
+STORAGE_AUTH_HINT = (
+    "[storage] Access to the workspace storage account was denied.\n"
+    "  If the account has shared key access disabled, this action needs a storage-scoped token:\n"
+    "    az account get-access-token --resource https://storage.azure.com --query accessToken -o tsv\n"
+    "  Pass it as the 'storage-token' action input (CLI: --storage-token), and grant the identity\n"
+    "  'Storage Blob Data Contributor' on the workspace storage account."
+)
+
+
+def storage_auth_hint(error: BaseException) -> Optional[str]:
+    """Return an actionable hint when an error chain looks like a denied blob request."""
+    seen: set[int] = set()
+    current: Optional[BaseException] = error
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        text = str(current).lower()
+        if any(marker in text for marker in _STORAGE_AUTH_MARKERS):
+            return STORAGE_AUTH_HINT
+        if any(marker in text for marker in _AMBIGUOUS_AUTH_MARKERS) and any(
+            marker in text for marker in _STORAGE_CONTEXT_MARKERS
+        ):
+            return STORAGE_AUTH_HINT
+        current = current.__cause__ or current.__context__
+    return None
 
 
 def empty_string_to_none_int(value: Optional[str]) -> Optional[int]:

--- a/inner-loop/test_action_contract.py
+++ b/inner-loop/test_action_contract.py
@@ -189,6 +189,25 @@ def test_waitfor_job_forwards_aml_token():
     assert invocation.argv[option_index + 1] == "aml-token-value"
 
 
+def test_deploy_data_forwards_storage_token():
+    values = _valid_inputs(("deploy", "data"))
+    values["storage-token"] = "storage-token-value"
+
+    invocation = adapt_action_environment(_action_environment(values))
+
+    option_index = invocation.argv.index("--storage-token")
+    assert invocation.argv[option_index + 1] == "storage-token-value"
+
+
+def test_storage_token_applies_to_deploy_commands_only():
+    for command, spec in COMMAND_SPECS.items():
+        assert ("storage-token" in spec.applicable_inputs) == (command[0] == "deploy"), command
+
+
+def test_storage_token_is_not_part_of_the_legacy_argument_contract():
+    assert "--storage-token" not in LEGACY_OPTION_INPUTS
+
+
 @pytest.mark.parametrize(
     ("command", "input_name"),
     APPLICABLE_CASES,

--- a/inner-loop/test_util.py
+++ b/inner-loop/test_util.py
@@ -27,7 +27,25 @@ from pathlib import Path
 from unittest.mock import patch, mock_open, MagicMock
 from collections import namedtuple
 
-from aip.inner.util import AML_SCOPE, Credential, github_output, load_safe_tags, get_ref_properties
+from aip.inner.util import (
+    AML_SCOPE,
+    STORAGE_SCOPE,
+    STORAGE_AUTH_HINT,
+    Credential,
+    github_output,
+    load_safe_tags,
+    get_ref_properties,
+    storage_auth_hint,
+)
+
+
+@pytest.fixture
+def fake_access_token():
+    with patch(
+        "aip.inner.util.AccessToken",
+        side_effect=lambda token, expires_on: MagicMock(token=token, expires_on=expires_on),
+    ):
+        yield
 
 
 class TestCredential:
@@ -42,6 +60,52 @@ class TestCredential:
 
         assert credential.get_token(AML_SCOPE).token == "aml-token"
         assert credential.get_token("https://management.azure.com/.default").token == "arm-token"
+
+    def test_get_token_selects_storage_token_for_storage_scope(self, fake_access_token):
+        credential = Credential("arm-token", 1234567890, "aml-token", "storage-token")
+
+        assert credential.get_token(STORAGE_SCOPE).token == "storage-token"
+        assert credential.get_token(AML_SCOPE).token == "aml-token"
+        assert credential.get_token("https://management.azure.com/.default").token == "arm-token"
+
+    def test_get_token_selects_storage_token_for_account_audience(self, fake_access_token):
+        credential = Credential("arm-token", 1234567890, storage_token="storage-token")
+
+        assert credential.get_token("https://acct.blob.core.windows.net/.default").token == "storage-token"
+        assert credential.get_token("https://acct.dfs.core.windows.net/.default").token == "storage-token"
+
+    def test_get_token_falls_back_to_arm_token_without_storage_token(self, fake_access_token):
+        credential = Credential("arm-token", 1234567890, "aml-token")
+
+        assert credential.get_token(STORAGE_SCOPE).token == "arm-token"
+
+
+class TestStorageAuthHint:
+    """Test suite for the storage authorization failure hint"""
+
+    def test_hint_returned_for_disabled_shared_key_access(self):
+        error = RuntimeError(
+            "KeyBasedAuthenticationNotPermitted: Key based authentication is not permitted"
+        )
+
+        assert storage_auth_hint(error) == STORAGE_AUTH_HINT
+
+    def test_hint_returned_for_wrapped_rbac_failure(self):
+        cause = RuntimeError("AuthorizationPermissionMismatch")
+        error = RuntimeError("upload failed")
+        error.__cause__ = cause
+
+        assert storage_auth_hint(error) == STORAGE_AUTH_HINT
+
+    def test_generic_authentication_failure_needs_storage_context(self):
+        assert storage_auth_hint(RuntimeError("AuthenticationFailed for the job")) is None
+        assert (
+            storage_auth_hint(RuntimeError("AuthenticationFailed for blob upload"))
+            == STORAGE_AUTH_HINT
+        )
+
+    def test_unrelated_error_returns_no_hint(self):
+        assert storage_auth_hint(RuntimeError("asset not found")) is None
 
 
 class TestGithubOutput:


### PR DESCRIPTION
## What
Support workspaces where shared access keys has been disabled.

## Why
With a disabled shared access key, RBAC is enforced.
When deploying assets that need uploading (data, components, environments, etc.) this requires a token scoped for storage based access.

## Changes
Deploy actions now allow an optional storage-token as input.

## Validation
- tests passed
- docker builds passed
