### PR TITLE
fix: Allow none as expected-current-deployment

### DIFF
--- a/inner-loop/README.md
+++ b/inner-loop/README.md
@@ -23,10 +23,10 @@ The Inner Loop action consolidates various Azure ML operations (deploy, share, w
 
 ### Batch Release Operations
 - ✅ **invoke batch-deployment**: Invoke one named deployment on a pinned data asset or URI
-- ✅ **promote batch-deployment**: Change the endpoint default with expected-current and post-update checks
+- ✅ **promote batch-deployment**: Change the endpoint default with an optional expected-current check and post-update verification
 - ✅ **rollback batch-deployment**: Restore an explicitly recorded prior default deployment
 
-Batch promotion and rollback are idempotent. A retry that already reached its target is a no-op; a different unexpected current default fails before mutation, and the result is read back after update. The SDK does not expose an ETag precondition, so orchestrating workflows must also use a GitHub concurrency group per endpoint.
+Batch promotion and rollback are idempotent. A retry that already reached its target is a no-op, and the result is read back after update. `expected-current-deployment` is optional: leave it blank to replace whatever default is there (the only option for an endpoint that has no default yet), or set it to fail before mutation when the default is not what the workflow observed. The SDK does not expose an ETag precondition, so orchestrating workflows must also use a GitHub concurrency group per endpoint.
 
 ### Share Operations
 - ✅ **share data**: Share data assets from workspace to registry

--- a/inner-loop/action.yaml
+++ b/inner-loop/action.yaml
@@ -108,7 +108,7 @@ inputs:
     description: "Optional deterministic name for a batch invocation job"
     required: false
   expected-current-deployment:
-    description: "Expected batch endpoint default used for guarded promotion or rollback"
+    description: "Optional expected batch endpoint default; when set, promotion or rollback fails if the default differs"
     required: false
 
 outputs:

--- a/inner-loop/src/aip/inner/batch.py
+++ b/inner-loop/src/aip/inner/batch.py
@@ -5,6 +5,26 @@ from typing import Optional
 import typer
 
 
+def _default_deployment_name(endpoint) -> Optional[str]:
+    """Read the default deployment name from either a mapping or a REST BatchEndpointDefaults."""
+    defaults = getattr(endpoint, "defaults", None)
+    if defaults is None:
+        return None
+    if isinstance(defaults, dict):
+        return defaults.get("deployment_name")
+    return getattr(defaults, "deployment_name", None)
+
+
+def _set_default_deployment_name(endpoint, deployment_name: str) -> None:
+    defaults = getattr(endpoint, "defaults", None)
+    if defaults is None:
+        endpoint.defaults = {"deployment_name": deployment_name}
+    elif isinstance(defaults, dict):
+        defaults["deployment_name"] = deployment_name
+    else:
+        defaults.deployment_name = deployment_name
+
+
 def set_default_deployment(
     client,
     *,
@@ -12,17 +32,17 @@ def set_default_deployment(
     target_deployment_name: str,
     expected_current_deployment: Optional[str],
 ):
-    """Set a batch endpoint default with idempotency and optimistic concurrency checks."""
+    """Set a batch endpoint default idempotently, verifying the result after update.
+
+    A blank `expected_current_deployment` replaces whatever default is there; supplying it
+    turns the update into an optimistic concurrency check.
+    """
     endpoint = client.batch_endpoints.get(name=endpoint_name)
-    current_deployment = (endpoint.defaults or {}).get("deployment_name")
+    current_deployment = _default_deployment_name(endpoint)
 
     if current_deployment == target_deployment_name:
         return endpoint, current_deployment, False
-    if not expected_current_deployment:
-        raise typer.BadParameter(
-            "--expected-current-deployment is required when changing a batch endpoint default"
-        )
-    if current_deployment != expected_current_deployment:
+    if expected_current_deployment and current_deployment != expected_current_deployment:
         raise typer.BadParameter(
             f"Batch endpoint '{endpoint_name}' default changed concurrently: "
             f"expected {expected_current_deployment!r}, found {current_deployment!r}"
@@ -32,10 +52,10 @@ def set_default_deployment(
         name=target_deployment_name,
         endpoint_name=endpoint_name,
     )
-    endpoint.defaults = {"deployment_name": target_deployment_name}
+    _set_default_deployment_name(endpoint, target_deployment_name)
     client.batch_endpoints.begin_create_or_update(endpoint).result()
     verified_endpoint = client.batch_endpoints.get(name=endpoint_name)
-    verified_default = (verified_endpoint.defaults or {}).get("deployment_name")
+    verified_default = _default_deployment_name(verified_endpoint)
     if verified_default != target_deployment_name:
         raise RuntimeError(
             f"Batch endpoint '{endpoint_name}' default update was not retained: "

--- a/inner-loop/test_batch_lifecycle.py
+++ b/inner-loop/test_batch_lifecycle.py
@@ -115,6 +115,74 @@ def test_set_default_deployment_rejects_concurrent_change():
     client.batch_endpoints.begin_create_or_update.assert_not_called()
 
 
+class _RestDefaults:
+    """Stand-in for the SDK's BatchEndpointDefaults model, which is not a mapping."""
+
+    def __init__(self, deployment_name=None):
+        self.deployment_name = deployment_name
+
+
+def test_set_default_deployment_reads_and_writes_rest_defaults_object():
+    endpoint = MagicMock()
+    endpoint.defaults = _RestDefaults("production-16")
+    verified = MagicMock()
+    verified.defaults = _RestDefaults("candidate-17")
+    client = MagicMock()
+    client.batch_endpoints.get.side_effect = [endpoint, verified]
+
+    result, previous, changed = set_default_deployment(
+        client,
+        endpoint_name="forecast-batch",
+        target_deployment_name="candidate-17",
+        expected_current_deployment="production-16",
+    )
+
+    assert previous == "production-16"
+    assert changed is True
+    assert result is verified
+    assert endpoint.defaults.deployment_name == "candidate-17"
+
+
+def test_set_default_deployment_is_idempotent_with_rest_defaults_object():
+    endpoint = MagicMock()
+    endpoint.defaults = _RestDefaults("candidate-17")
+    client = MagicMock()
+    client.batch_endpoints.get.return_value = endpoint
+
+    _, previous, changed = set_default_deployment(
+        client,
+        endpoint_name="forecast-batch",
+        target_deployment_name="candidate-17",
+        expected_current_deployment=None,
+    )
+
+    assert previous == "candidate-17"
+    assert changed is False
+    client.batch_endpoints.begin_create_or_update.assert_not_called()
+
+
+def test_set_default_deployment_replaces_unconditionally_without_expected_current():
+    endpoint = MagicMock()
+    endpoint.defaults = None
+    verified = MagicMock()
+    verified.defaults = {"deployment_name": "candidate-17"}
+    client = MagicMock()
+    client.batch_endpoints.get.side_effect = [endpoint, verified]
+
+    result, previous, changed = set_default_deployment(
+        client,
+        endpoint_name="forecast-batch",
+        target_deployment_name="candidate-17",
+        expected_current_deployment=None,
+    )
+
+    assert previous is None
+    assert changed is True
+    assert result is verified
+    assert endpoint.defaults == {"deployment_name": "candidate-17"}
+    client.batch_endpoints.begin_create_or_update.assert_called_once_with(endpoint)
+
+
 def test_set_default_deployment_rejects_unretained_update():
     before = MagicMock()
     before.defaults = {"deployment_name": "production-16"}


### PR DESCRIPTION
## What
Allow 'none' as input to expected-current-deployment

## Why
When promoting a batch deployment, the wf might not know what the current deployment is.

## Changes
Allow 'none' as input to expected-current-deployment

## Validation
- tests passed
- docker builds passed
