### PR TITLE
fix: inner-loop invoke batch-endpoint normalizes input_path

### DIFF
--- a/inner-loop/README.md
+++ b/inner-loop/README.md
@@ -22,7 +22,7 @@ The Inner Loop action consolidates various Azure ML operations (deploy, share, w
 - ✅ **deploy batch-deployment**: Create or update a versioned batch deployment
 
 ### Batch Release Operations
-- ✅ **invoke batch-deployment**: Invoke one named deployment on a pinned data asset or URI
+- ✅ **invoke batch-deployment**: Invoke one named deployment on a pinned data asset, datastore URI or preceding job's output
 - ✅ **promote batch-deployment**: Change the endpoint default with an optional expected-current check and post-update verification
 - ✅ **rollback batch-deployment**: Restore an explicitly recorded prior default deployment
 
@@ -336,6 +336,45 @@ instance_count: 1
 
 The waitfor verb polls Azure ML every 10 seconds (up to 30 minutes) until the specified asset exists and reports a success status. If the asset reports a failure state or the timeout expires, the action stops with a failure, allowing pipelines to halt early when provisioned artifacts break.
 
+### Invoke a Batch Deployment
+
+```yaml
+- uses: ./inner-loop
+  with:
+    verb: invoke
+    subject: batch-deployment
+    token: ${{ steps.azure-login.outputs.access-token }}
+    expires-on: ${{ steps.azure-login.outputs.expires-on }}
+    aml-token: ${{ steps.azure-login.outputs.aml-token }}
+    subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+    resource-group: my-resource-group
+    workspace-name: my-workspace
+    endpoint-name: forecast-batch
+    deployment-name: candidate-17
+    input-path: azureml://jobs/${{ steps.generate-inference-data.outputs.version }}/outputs/scored
+    input-type: uri_folder
+```
+
+The invocation targets one named deployment directly, so it validates a candidate without touching endpoint traffic or the endpoint default. Use `promote batch-deployment` once the invocation result is accepted.
+
+**Accepted `input-path` forms:**
+
+| Form | Example |
+|------|---------|
+| Job output reference | `azureml://jobs/<job-name>/outputs/<output-name>` |
+| Job output subpath | `azureml://jobs/<job-name>/outputs/<output-name>/paths/<file>` |
+| Short datastore URI | `azureml://datastores/<datastore>/paths/<path>` |
+| Long datastore URI | `azureml://subscriptions/<sub>/resourcegroups/<rg>/workspaces/<ws>/datastores/<datastore>/paths/<path>` |
+| Registered data asset | `azureml:<name>:<version>` or `azureml:<name>@latest` |
+| Public URI | `https://<host>/<path>` |
+| Local path | `./data/validation` (uploaded to the workspace datastore) |
+
+Azure ML batch endpoints only consume datastore URIs, registered data assets, public URIs and local paths. Job output references are the natural handoff from a preceding `deploy job` step, so the action resolves them to the underlying datastore URI before invoking, and appends the trailing `/` that `uri_folder` inputs require. Any other `azureml://` URI is rejected up front with the list of accepted forms instead of the SDK's generic validation error.
+
+`invocation-job-name` pins the name of the created Azure ML job, which makes a retried workflow run observable under a known name. Leave it blank to let Azure ML generate one; a rerun with an already-used name fails. `experiment-name` groups the invocation job in the Azure ML studio experiment view.
+
+Outputs: `invocation-job-name` and `version` carry the submitted job name, `status` its initial status, and `resource-id` its resource ID. Chain `waitfor job` on `invocation-job-name` to block until the batch job reaches a terminal state.
+
 ### Share to Registry with Stage Promotion
 
 ```yaml
@@ -378,8 +417,8 @@ The waitfor verb polls Azure ML every 10 seconds (up to 30 minutes) until the sp
 
 | Input | Required | Description |
 |-------|----------|-------------|
-| `verb` | Yes | Action verb: `deploy`, `share`, `waitfor`, or `delete` |
-| `subject` | Yes | Target subject: `data`, `environment`, `component`, `model`, `job`, `online-endpoint`, or `online-deployment` |
+| `verb` | Yes | Action verb: `deploy`, `share`, `waitfor`, `delete`, `invoke`, `promote`, or `rollback` |
+| `subject` | Yes | Target subject: `data`, `environment`, `component`, `model`, `job`, `online-endpoint`, `online-deployment`, `batch-endpoint`, or `batch-deployment` |
 | `token` | No* | Access token from Azure login action (*required for GitHub Actions) |
 | `expires-on` | No* | Token expiration timestamp from Azure login action (*required for GitHub Actions) |
 | `aml-token` | No | Access token with Azure ML scope for `deploy job`, `deploy sweep-job`, and `waitfor job`; optional when `DefaultAzureCredential` is available locally |
@@ -396,8 +435,14 @@ The waitfor verb polls Azure ML every 10 seconds (up to 30 minutes) until the sp
 | `env-ref` | No* | Environment name (*for share environment) |
 | `model-ref` | No* | Model name (*for share model) |
 | `job-name` | No* | Job name (*for waitfor job) |
-| `endpoint-name` | No* | Online endpoint name (*for waitfor/delete online-endpoint) |
+| `endpoint-name` | No* | Endpoint name (*for waitfor/delete online-endpoint and for invoke/promote/rollback batch-deployment) |
+| `deployment-name` | No* | Deployment name (*required for invoke/promote/rollback batch-deployment) |
 | `deployment-resource` | No* | Online deployment resource ID (*for waitfor/delete online-deployment) |
+| `input-path` | No* | Pinned data asset or URI used to invoke a batch deployment (*required for invoke batch-deployment) |
+| `input-type` | No | Batch invocation input type: `uri_folder` (default) or `uri_file` |
+| `invocation-job-name` | No | Deterministic name for the created batch invocation job |
+| `experiment-name` | No | Azure ML experiment name (for `deploy job`, `deploy sweep-job`, `invoke batch-deployment`) |
+| `expected-current-deployment` | No | Expected batch endpoint default; promotion or rollback fails when the actual default differs |
 | `traffic-allocation` | No | Traffic percentage (0-100) to allocate to deployment |
 | `tags` | No | Tags in format: `key1=value1,key2=value2` |
 | `promote-stage` | No | Stage to promote asset to (e.g., "Production") |
@@ -410,6 +455,14 @@ The waitfor verb polls Azure ML every 10 seconds (up to 30 minutes) until the sp
 | `resource-id` | Full Azure resource ID of the created/shared resource |
 | `reference` | Azure ML reference string (e.g., `azureml:name:version`) |
 | `version` | Version number of the resource (or job name for jobs) |
+| `lineage-metadata` | JSON-encoded lineage metadata for a submitted job (git SHA, branch, workflow run ID) |
+| `best-trial-run-id` | Run ID of the best trial in a completed sweep job |
+| `invocation-job-name` | Azure ML job created by `invoke batch-deployment` |
+| `status` | Status of the submitted batch invocation job |
+| `previous-deployment-name` | Batch endpoint default before promotion |
+| `replaced-deployment-name` | Batch endpoint default replaced during rollback |
+| `default-deployment-name` | Batch endpoint default after promotion or rollback |
+| `changed` | Whether promotion or rollback changed the endpoint |
 
 ## Complete Example Pipeline
 

--- a/inner-loop/action.yaml
+++ b/inner-loop/action.yaml
@@ -99,7 +99,7 @@ inputs:
     description: "Azure ML experiment name (for deploy job, deploy sweep-job). Overrides the experiment name in the YAML."
     required: false
   input-path:
-    description: "Pinned Azure ML data asset or URI used to invoke a batch deployment"
+    description: "Data asset, datastore URI, job output reference (azureml://jobs/<job>/outputs/<output>), public URI or local path used to invoke a batch deployment"
     required: false
   input-type:
     description: "Batch invocation input type (uri_file or uri_folder)"

--- a/inner-loop/src/aip/inner/invoke.py
+++ b/inner-loop/src/aip/inner/invoke.py
@@ -1,5 +1,6 @@
 """Invocation operations for Azure ML deployment validation."""
 
+import re
 from typing import Annotated, Optional
 
 import typer
@@ -8,6 +9,68 @@ from azure.ai.ml import Input
 from .util import empty_string_to_none, get_workspace_client, github_output
 
 app = typer.Typer()
+
+JOB_OUTPUT_REFERENCE = re.compile(
+    r"^azureml://jobs/(?P<job>[^/]+)/outputs/(?P<output>[^/]+)(?:/paths/(?P<suffix>.*))?/?$",
+    re.IGNORECASE,
+)
+DATASTORE_URI = re.compile(
+    r"^azureml://(subscriptions/[^/]+/resource[gG]roups/[^/]+/workspaces/[^/]+/)?datastores/[^/]+/paths/.+",
+    re.IGNORECASE,
+)
+REMOTE_URI_PREFIXES = ("azureml://", "http://", "https://")
+
+SUPPORTED_INPUT_FORMS = (
+    "azureml://jobs/<job-name>/outputs/<output-name>",
+    "azureml://datastores/<datastore>/paths/<path>",
+    "azureml://subscriptions/<sub>/resourcegroups/<rg>/workspaces/<ws>/datastores/<datastore>/paths/<path>",
+    "azureml:<data-asset-name>:<version>",
+    "azureml:<data-asset-name>@latest",
+    "https://<public-uri>",
+    "<local-path>",
+)
+
+
+def resolve_job_output_path(client, job_name: str, output_name: str, suffix: Optional[str]) -> str:
+    """Translate a job-output reference into the datastore URI that batch invocation accepts."""
+    # The SDK rejects azureml://jobs/... paths, so reuse the resolution that jobs.download relies on.
+    resolver = getattr(client.jobs, "_get_named_output_uri", None)
+    resolved = resolver(job_name, output_name).get(output_name) if resolver else None
+
+    if not resolved:
+        job_outputs = getattr(client.jobs.get(job_name), "outputs", None) or {}
+        resolved = getattr(job_outputs.get(output_name), "path", None)
+
+    if not resolved:
+        raise typer.BadParameter(
+            f"Output '{output_name}' of job '{job_name}' has no resolvable storage location. "
+            "Confirm the job completed and that the output name matches its definition."
+        )
+
+    resolved = resolved.rstrip("/")
+    return f"{resolved}/{suffix}" if suffix else resolved
+
+
+def normalize_input_path(client, input_path: str, input_type: str) -> str:
+    """Resolve job-output references and reject URI shapes that batch invocation cannot consume."""
+    job_output = JOB_OUTPUT_REFERENCE.match(input_path)
+    if job_output:
+        input_path = resolve_job_output_path(
+            client,
+            job_output.group("job"),
+            job_output.group("output"),
+            job_output.group("suffix"),
+        )
+    elif input_path.lower().startswith("azureml://") and not DATASTORE_URI.match(input_path):
+        supported = "\n  ".join(SUPPORTED_INPUT_FORMS)
+        raise typer.BadParameter(
+            f"--input-path '{input_path}' is not a URI that a batch endpoint can consume.\n"
+            f"Supported forms:\n  {supported}"
+        )
+
+    if input_type == "uri_folder" and input_path.lower().startswith(REMOTE_URI_PREFIXES) and not input_path.endswith("/"):
+        input_path += "/"
+    return input_path
 
 
 @app.command()
@@ -39,7 +102,10 @@ def batch_deployment(
         expires_on=int(expires_on) if expires_on else None,
         aml_token=aml_token,
     )
-    invocation_input = Input(path=input_path, type=input_type)
+    resolved_path = normalize_input_path(client, input_path, input_type)
+    if resolved_path != input_path:
+        print(f"[invoke batch-deployment] Resolved '{input_path}' to '{resolved_path}'")
+    invocation_input = Input(path=resolved_path, type=input_type)
     invocation = client.batch_endpoints.invoke(
         endpoint_name=endpoint_name,
         deployment_name=deployment_name,

--- a/inner-loop/test_batch_lifecycle.py
+++ b/inner-loop/test_batch_lifecycle.py
@@ -294,6 +294,99 @@ def test_invoke_named_batch_deployment_uses_pinned_input():
     assert output.call_args.args[0]["invocation-job-name"] == "validation-job-17"
 
 
+def test_invoke_resolves_job_output_reference_to_datastore_uri():
+    client = MagicMock()
+    client.jobs._get_named_output_uri.return_value = {
+        "scored": "azureml://datastores/workspaceblobstore/paths/azureml/run-guid/scored/"
+    }
+    invocation = MagicMock()
+    invocation.name = "validation-job-18"
+    client.batch_endpoints.invoke.return_value = invocation
+
+    with (
+        patch("aip.inner.invoke.get_workspace_client", return_value=client),
+        patch("aip.inner.invoke.Input") as input_factory,
+        patch("aip.inner.invoke.github_output"),
+    ):
+        invoke.batch_deployment(
+            "subscription",
+            "resource-group",
+            "workspace",
+            "forecast-batch",
+            "candidate-18",
+            "azureml://jobs/musing_thread_mjx4lbyg7r/outputs/scored",
+            "uri_folder",
+        )
+
+    client.jobs._get_named_output_uri.assert_called_once_with("musing_thread_mjx4lbyg7r", "scored")
+    input_factory.assert_called_once_with(
+        path="azureml://datastores/workspaceblobstore/paths/azureml/run-guid/scored/",
+        type="uri_folder",
+    )
+
+
+def test_normalize_input_path_appends_job_output_subpath():
+    client = MagicMock()
+    client.jobs._get_named_output_uri.return_value = {
+        "scored": "azureml://datastores/workspaceblobstore/paths/azureml/run-guid/scored/"
+    }
+
+    resolved = invoke.normalize_input_path(
+        client, "azureml://jobs/run-guid/outputs/scored/paths/predictions.csv", "uri_file"
+    )
+
+    assert resolved == "azureml://datastores/workspaceblobstore/paths/azureml/run-guid/scored/predictions.csv"
+
+
+def test_normalize_input_path_falls_back_to_declared_job_output_path():
+    client = MagicMock()
+    client.jobs._get_named_output_uri.return_value = {}
+    client.jobs.get.return_value.outputs = {
+        "scored": MagicMock(path="azureml://datastores/pinned/paths/exports/scored")
+    }
+
+    resolved = invoke.normalize_input_path(client, "azureml://jobs/run-guid/outputs/scored", "uri_folder")
+
+    client.jobs.get.assert_called_once_with("run-guid")
+    assert resolved == "azureml://datastores/pinned/paths/exports/scored/"
+
+
+def test_normalize_input_path_rejects_unresolvable_job_output():
+    client = MagicMock()
+    client.jobs._get_named_output_uri.return_value = {}
+    client.jobs.get.return_value.outputs = {}
+
+    with pytest.raises(typer.BadParameter):
+        invoke.normalize_input_path(client, "azureml://jobs/run-guid/outputs/missing", "uri_folder")
+
+
+def test_normalize_input_path_rejects_unsupported_azureml_uri():
+    with pytest.raises(typer.BadParameter):
+        invoke.normalize_input_path(MagicMock(), "azureml://locations/westeurope/workspaces/ws/data/x/versions/1", "uri_folder")
+
+
+@pytest.mark.parametrize(
+    "input_path, input_type, expected",
+    [
+        (
+            "azureml://datastores/workspaceblobstore/paths/exports/scored",
+            "uri_folder",
+            "azureml://datastores/workspaceblobstore/paths/exports/scored/",
+        ),
+        (
+            "azureml://datastores/workspaceblobstore/paths/exports/scored.csv",
+            "uri_file",
+            "azureml://datastores/workspaceblobstore/paths/exports/scored.csv",
+        ),
+        ("azureml:validation-data:4", "uri_folder", "azureml:validation-data:4"),
+        ("azureml:validation-data@latest", "uri_folder", "azureml:validation-data@latest"),
+        ("./local/inputs", "uri_folder", "./local/inputs"),
+    ],
+)
+def test_normalize_input_path_preserves_supported_forms(input_path, input_type, expected):
+    assert invoke.normalize_input_path(MagicMock(), input_path, input_type) == expected
+
+
 def test_action_adapter_routes_promote_arguments_and_environment():
     endpoint = MagicMock()
     endpoint.defaults = {"deployment_name": "production-16"}


### PR DESCRIPTION
## What
Inner-loop invoke batch-endpoint now normalizes input_path.

## Why
The underlying SDK calls require input shapes that are unsuitable and unwieldy for chaining in workflows:
the main usecase for this repository needs to solve. Previously required users to find run_id from job names for each use.

## Changes
Wider (and more logical) scope for input_path, documented in inner-loop/README.md.

## Validation
- tests passed
- docker builds passed
